### PR TITLE
Self-contained evaluation scripts for DRB and SQA-CS-V2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,6 @@ uv.lock
 import
 PY
 eval_output/
+agent/evaluation/sqa_eval/test.jsonl
+agent/evaluation/sqa_eval/test_asta_format.jsonl
+agent/evaluation/deep_research_bench_eval/data/

--- a/agent/evaluation/README.md
+++ b/agent/evaluation/README.md
@@ -63,11 +63,117 @@ for task in healthbench deep_research_bench research_qa genetic_diseases simpleq
 done
 ```
 
-For SQA-CS-V2 evaluation, see the dedicated section below.
+For SQA-CS-V2 and Deep Research Bench evaluations, see the dedicated sections below.
 
 ---
 
-## Additional instructions on SQA-CS-V2 Evaluation
+## Deep Research Bench (DRB) Evaluation — Self-Contained
+
+DRB evaluation measures deep research report quality using two metrics:
+- **RACE**: Reference-based and Adaptive Criteria-driven Evaluation (article quality)
+- **FACT**: Factual Abundance and Citation Trustworthiness (citation verification)
+
+### Prerequisites
+
+```bash
+pip install google-genai tqdm
+export GEMINI_API_KEY="your_gemini_api_key_here"
+```
+
+### Quick Start (Self-Contained — No External Repo Needed)
+
+```bash
+# Full pipeline: format conversion + RACE + FACT evaluation
+python evaluation/deep_research_bench_eval/run_eval.py \
+    --input_file eval_output/auto_search_sft/deep_research_bench.jsonl \
+    --task_name my_model
+
+# RACE only (skip FACT):
+python evaluation/deep_research_bench_eval/run_eval.py \
+    --input_file eval_output/auto_search_sft/deep_research_bench.jsonl \
+    --task_name my_model --skip_fact
+
+# FACT only (skip RACE):
+python evaluation/deep_research_bench_eval/run_eval.py \
+    --input_file eval_output/auto_search_sft/deep_research_bench.jsonl \
+    --task_name my_model --skip_race
+
+# Test with limit:
+python evaluation/deep_research_bench_eval/run_eval.py \
+    --input_file eval_output/auto_search_sft/deep_research_bench.jsonl \
+    --task_name my_model --limit 2
+
+# English only:
+python evaluation/deep_research_bench_eval/run_eval.py \
+    --input_file eval_output/auto_search_sft/deep_research_bench.jsonl \
+    --task_name my_model --only_en
+```
+
+### Or via the unified evaluate.py script
+
+```bash
+python scripts/evaluate.py deep_research_bench eval_output/auto_search_sft/deep_research_bench.jsonl
+```
+
+### Output Structure
+
+```
+<output_dir>/
+├── raw_data/<task_name>.jsonl          # Formatted articles
+├── cleaned_data/<task_name>.jsonl      # Cleaned articles (citations removed)
+├── race/<task_name>/
+│   ├── raw_results.jsonl               # Per-item RACE scores
+│   └── race_result.txt                 # Aggregated RACE metrics
+└── fact/<task_name>/
+    ├── scraped.jsonl                   # Articles with scraped citation content
+    ├── validated.jsonl                 # Validated citations
+    └── fact_result.txt                 # Aggregated FACT metrics
+```
+
+---
+
+## SQA-CS-V2 Evaluation — Self-Contained
+
+SQA-CS-V2 evaluates scientific question answering with structured citations.
+
+### Prerequisites
+
+```bash
+pip install astabench==0.3.1 inspect_ai datasets
+export GOOGLE_API_KEY="your_google_api_key_here"
+export HF_TOKEN="your_hf_token_here"   # Can be dummy if not downloading data
+```
+
+### Quick Start (Self-Contained — No External Repo Needed)
+
+```bash
+# Full pipeline: convert + evaluate
+python evaluation/sqa_eval/run_eval.py run \
+    --input_file eval_output/auto_search_sft/sqa_cs_v2.jsonl
+
+# Step-by-step:
+# 1. Convert DR Tulu output to ASTA format
+python evaluation/sqa_eval/run_eval.py convert \
+    --input_file eval_output/auto_search_sft/sqa_cs_v2.jsonl
+
+# 2. Run evaluation
+python evaluation/sqa_eval/run_eval.py eval \
+    --input_file eval_output/auto_search_sft/sqa_cs_v2_asta_format.jsonl
+
+# With custom scorer model:
+python evaluation/sqa_eval/run_eval.py run \
+    --input_file eval_output/auto_search_sft/sqa_cs_v2.jsonl \
+    --scorer_model "google/gemini-2.5-flash" \
+    --max_connections 16
+```
+
+### Or via the unified evaluate.py script
+
+```bash
+python scripts/evaluate.py sqa_cs_v2 eval_output/auto_search_sft/sqa_cs_v2.jsonl
+```
+
+### SQA Response Format
 
 SQA-CS-V2 requires responses in a specific JSON format with structured sections and citations:
 
@@ -76,28 +182,21 @@ SQA-CS-V2 requires responses in a specific JSON format with structured sections 
   "sections": [
     {
       "text": "text of section 1",
-      "citations": {
-        "id": "cite 1 of sec 1",
-        "snippets": [
-          "evidence 1",
-          "evidence 2"
-        ]
-      }
-    },
-    {
-      "text": "text of section 2",
-      "citations": {
-        "id": "cite 1 of sec 2",
-        "snippets": [
-          "List of evidence"
-        ]
-      }
+      "citations": [
+        {
+          "id": "[cite_id]",
+          "title": "paper title",
+          "snippets": ["evidence 1", "evidence 2"]
+        }
+      ]
     }
   ]
 }
 ```
 
-### Evaluation Steps
+### Legacy Method (External Repo)
+
+If you prefer using the original agent-baselines repository:
 
 1. **Convert DR Tulu outputs to SQA format**:
    ```bash
@@ -125,5 +224,5 @@ SQA-CS-V2 requires responses in a specific JSON format with structured sections 
      -T scorer_model="google/gemini-2.5-flash"
    ```
 
-**Note**: Export `GOOGLE_API_KEY` and `HF_TOKEN` before running. If errors request additional tokens, dummy values can be used.
+**Note**: Export `GOOGLE_API_KEY` and `HF_TOKEN` before running.
 

--- a/agent/evaluation/README.md
+++ b/agent/evaluation/README.md
@@ -76,9 +76,11 @@ DRB evaluation measures deep research report quality using two metrics:
 ### Prerequisites
 
 ```bash
-pip install google-genai tqdm
+pip install google-genai tqdm huggingface_hub
 export GEMINI_API_KEY="your_gemini_api_key_here"
 ```
+
+> **Note**: DRB reference data (query, criteria, reference articles) is hosted at [`rl-research/dr-tulu-eval-data`](https://huggingface.co/datasets/rl-research/dr-tulu-eval-data) and will be auto-downloaded on first run.
 
 ### Quick Start (Self-Contained — No External Repo Needed)
 
@@ -141,7 +143,7 @@ SQA-CS-V2 evaluates scientific question answering with structured citations.
 ```bash
 pip install astabench==0.3.1 inspect_ai datasets
 export GOOGLE_API_KEY="your_google_api_key_here"
-export HF_TOKEN="your_hf_token_here"   # Can be dummy if not downloading data
+export HF_TOKEN="your_hf_token_here"   # Needs access to allenai/asta-bench (gated dataset)
 ```
 
 ### Quick Start (Self-Contained — No External Repo Needed)

--- a/agent/evaluation/README.md
+++ b/agent/evaluation/README.md
@@ -63,168 +63,42 @@ for task in healthbench deep_research_bench research_qa genetic_diseases simpleq
 done
 ```
 
-For SQA-CS-V2 and Deep Research Bench evaluations, see the dedicated sections below.
+For SQA-CS-V2 and Deep Research Bench evaluations, see the dedicated READMEs in their subdirectories.
 
 ---
 
-## Deep Research Bench (DRB) Evaluation — Self-Contained
+## Deep Research Bench (DRB) Evaluation
 
-DRB evaluation measures deep research report quality using two metrics:
-- **RACE**: Reference-based and Adaptive Criteria-driven Evaluation (article quality)
-- **FACT**: Factual Abundance and Citation Trustworthiness (citation verification)
-
-### Prerequisites
+See [`deep_research_bench_eval/README.md`](deep_research_bench_eval/README.md) for full instructions.
 
 ```bash
+# Quick start (self-contained, no external repo needed)
 pip install google-genai tqdm huggingface_hub
-export GEMINI_API_KEY="your_gemini_api_key_here"
-```
+export GEMINI_API_KEY="your_key"
 
-> **Note**: DRB reference data (query, criteria, reference articles) is hosted at [`rl-research/dr-tulu-eval-data`](https://huggingface.co/datasets/rl-research/dr-tulu-eval-data) and will be auto-downloaded on first run.
-
-### Quick Start (Self-Contained — No External Repo Needed)
-
-```bash
-# Full pipeline: format conversion + RACE + FACT evaluation
 python evaluation/deep_research_bench_eval/run_eval.py \
     --input_file eval_output/auto_search_sft/deep_research_bench.jsonl \
     --task_name my_model
 
-# RACE only (skip FACT):
-python evaluation/deep_research_bench_eval/run_eval.py \
-    --input_file eval_output/auto_search_sft/deep_research_bench.jsonl \
-    --task_name my_model --skip_fact
-
-# FACT only (skip RACE):
-python evaluation/deep_research_bench_eval/run_eval.py \
-    --input_file eval_output/auto_search_sft/deep_research_bench.jsonl \
-    --task_name my_model --skip_race
-
-# Test with limit:
-python evaluation/deep_research_bench_eval/run_eval.py \
-    --input_file eval_output/auto_search_sft/deep_research_bench.jsonl \
-    --task_name my_model --limit 2
-
-# English only:
-python evaluation/deep_research_bench_eval/run_eval.py \
-    --input_file eval_output/auto_search_sft/deep_research_bench.jsonl \
-    --task_name my_model --only_en
-```
-
-### Or via the unified evaluate.py script
-
-```bash
+# Or via unified script:
 python scripts/evaluate.py deep_research_bench eval_output/auto_search_sft/deep_research_bench.jsonl
-```
-
-### Output Structure
-
-```
-<output_dir>/
-├── raw_data/<task_name>.jsonl          # Formatted articles
-├── cleaned_data/<task_name>.jsonl      # Cleaned articles (citations removed)
-├── race/<task_name>/
-│   ├── raw_results.jsonl               # Per-item RACE scores
-│   └── race_result.txt                 # Aggregated RACE metrics
-└── fact/<task_name>/
-    ├── scraped.jsonl                   # Articles with scraped citation content
-    ├── validated.jsonl                 # Validated citations
-    └── fact_result.txt                 # Aggregated FACT metrics
 ```
 
 ---
 
-## SQA-CS-V2 Evaluation — Self-Contained
+## SQA-CS-V2 Evaluation
 
-SQA-CS-V2 evaluates scientific question answering with structured citations.
-
-### Prerequisites
+See [`sqa_eval/README.md`](sqa_eval/README.md) for full instructions.
 
 ```bash
-pip install astabench==0.3.1 inspect_ai datasets
-export GOOGLE_API_KEY="your_google_api_key_here"
-export HF_TOKEN="your_hf_token_here"   # Needs access to allenai/asta-bench (gated dataset)
-```
+# Quick start (self-contained, no external repo needed)
+pip install uv
+export GOOGLE_API_KEY="your_key"
 
-### Quick Start (Self-Contained — No External Repo Needed)
-
-```bash
-# Full pipeline: convert + evaluate
 python evaluation/sqa_eval/run_eval.py run \
     --input_file eval_output/auto_search_sft/sqa_cs_v2.jsonl
 
-# Step-by-step:
-# 1. Convert DR Tulu output to ASTA format
-python evaluation/sqa_eval/run_eval.py convert \
-    --input_file eval_output/auto_search_sft/sqa_cs_v2.jsonl
-
-# 2. Run evaluation
-python evaluation/sqa_eval/run_eval.py eval \
-    --input_file eval_output/auto_search_sft/sqa_cs_v2_asta_format.jsonl
-
-# With custom scorer model:
-python evaluation/sqa_eval/run_eval.py run \
-    --input_file eval_output/auto_search_sft/sqa_cs_v2.jsonl \
-    --scorer_model "google/gemini-2.5-flash" \
-    --max_connections 16
-```
-
-### Or via the unified evaluate.py script
-
-```bash
+# Or via unified script:
 python scripts/evaluate.py sqa_cs_v2 eval_output/auto_search_sft/sqa_cs_v2.jsonl
 ```
-
-### SQA Response Format
-
-SQA-CS-V2 requires responses in a specific JSON format with structured sections and citations:
-
-```json
-{
-  "sections": [
-    {
-      "text": "text of section 1",
-      "citations": [
-        {
-          "id": "[cite_id]",
-          "title": "paper title",
-          "snippets": ["evidence 1", "evidence 2"]
-        }
-      ]
-    }
-  ]
-}
-```
-
-### Legacy Method (External Repo)
-
-If you prefer using the original agent-baselines repository:
-
-1. **Convert DR Tulu outputs to SQA format**:
-   ```bash
-   python evaluation/sqa_eval/convert_to_asta_format.py --folder <folder_name> --file <file_name>
-   ```
-
-2. **Clone the evaluation repository**:
-   ```bash
-   git clone https://github.com/allenai/agent-baselines
-   cd agent-baselines
-   ```
-
-3. **Run evaluation**:
-   ```bash
-   uv run --extra sqa inspect eval astabench/sqa --display plain \
-     --solver agent_baselines/solvers/sqa/debug/cached_solver.py \
-     -S path=<outputfile_from_step1> \
-     -T split=test \
-     -T with_search_tools=False \
-     -T simplified_eval=true \
-     -T assess_jointly=true \
-     --max-connections 16 \
-     -T sentence_wise_cit_eval=false \
-     -T all_at_once=true \
-     -T scorer_model="google/gemini-2.5-flash"
-   ```
-
-**Note**: Export `GOOGLE_API_KEY` and `HF_TOKEN` before running.
 

--- a/agent/evaluation/deep_research_bench_eval/README.md
+++ b/agent/evaluation/deep_research_bench_eval/README.md
@@ -1,40 +1,99 @@
 ## Introduction
 
-We conduct external evaluation on Deep Research Bench (DRB) with [their original repository](https://github.com/Ayanami0730/deep_research_bench) to aquire the evaluation results for two different metrics: 1. Reference-based and Adaptive Criteria-driven Evaluation framework with Dynamic Weighting (RACE) and 2. Factual Abundance and Citation Trustworthiness (FACT)
+We evaluate on Deep Research Bench (DRB) to acquire results for two metrics:
+1. **RACE** (Reference-based and Adaptive Criteria-driven Evaluation framework with Dynamic Weighting) — article quality
+2. **FACT** (Factual Abundance and Citation Trustworthiness) — citation verification
 
-We provide our format conversion script and step-by-step instructions as follows.
+---
 
+## Self-Contained Evaluation (Recommended)
 
-## Steps
+The self-contained script `run_eval.py` bundles all evaluation code and data. **No external repo needed.**
+
+### Prerequisites
+
+```bash
+pip install google-genai tqdm
+export GEMINI_API_KEY="your_gemini_api_key_here"
+```
+
+### Quick Start
+
+```bash
+# Full pipeline: format conversion + RACE + FACT
+python evaluation/deep_research_bench_eval/run_eval.py \
+    --input_file eval_output/auto_search_sft/deep_research_bench.jsonl \
+    --task_name my_model
+
+# RACE only:
+python evaluation/deep_research_bench_eval/run_eval.py \
+    --input_file eval_output/auto_search_sft/deep_research_bench.jsonl \
+    --task_name my_model --skip_fact
+
+# FACT only:
+python evaluation/deep_research_bench_eval/run_eval.py \
+    --input_file eval_output/auto_search_sft/deep_research_bench.jsonl \
+    --task_name my_model --skip_race
+
+# Test with limit:
+python evaluation/deep_research_bench_eval/run_eval.py \
+    --input_file eval_output/auto_search_sft/deep_research_bench.jsonl \
+    --task_name my_model --limit 2
+
+# English only / Chinese only:
+python evaluation/deep_research_bench_eval/run_eval.py \
+    --input_file eval_output/auto_search_sft/deep_research_bench.jsonl \
+    --task_name my_model --only_en
+```
+
+### Via the unified evaluate.py
+
+```bash
+python scripts/evaluate.py deep_research_bench eval_output/auto_search_sft/deep_research_bench.jsonl
+```
+
+### Output Structure
+
+```
+<output_dir>/
+├── raw_data/<task_name>.jsonl          # Formatted articles
+├── cleaned_data/<task_name>.jsonl      # Cleaned articles (citations removed)
+├── race/<task_name>/
+│   ├── raw_results.jsonl               # Per-item RACE scores
+│   └── race_result.txt                 # Aggregated RACE metrics
+└── fact/<task_name>/
+    ├── scraped.jsonl                   # Articles with scraped citation content
+    ├── validated.jsonl                 # Validated citations
+    └── fact_result.txt                 # Aggregated FACT metrics
+```
+
+### Evaluation Data
+
+Data files are automatically downloaded from [rl-research/dr-tulu-eval-data](https://huggingface.co/datasets/rl-research/dr-tulu-eval-data) on HuggingFace:
+- `query.jsonl` — 100 evaluation queries (50 EN + 50 ZH)
+- `criteria.jsonl` — Task-specific evaluation criteria with weights
+- `reference.jsonl` — Reference articles for comparison (from Claude 3.7 Sonnet)
+
+If you prefer local files, place them in `data/` with the original directory structure and they will be used instead.
+
+---
+
+## Legacy Method (External Repo)
+
+If you prefer using the [original DRB repository](https://github.com/Ayanami0730/deep_research_bench):
 
 ### 1. Generate the DRB output from our system
-Our repository supports the generation natively. Add `deep_research_bench` to the task in the scripts, e.g., `agent/scripts/auto_search.sh`, to acquire the output. The default path will be `eval_output/auto_search_sft/deep_research_bench-ablation-s2.jsonl`
+Add `deep_research_bench` to the task in the scripts, e.g., `agent/scripts/auto_search.sh`.
 
-### 2. Conduct format conversion and place the files into the original repository
-In the original DRB evaluation, the authors use [JINA API](https://jina.ai/) to scrape the URLs in the generated deep research reports. In our pipeline, since we already acquire the URL content through our search and browering, we directly use the scraped content to pair with the sentences in the article for citation evaluation.
-
-Our format conversion code is in `drb_formatter.py`. It requires three positional arguments: 
-- input_file_path: the path to the output file from our system.
-- task_name: the identifier of this task, e.g., deep_research_bench-ablation-s2.
-- drb_repo_path: the path to the official DRB repo (details in Step 3), where the formatted data will be stored.
-
-A full example:
+### 2. Format conversion
 ```bash
 python drb_formatter.py \
     --input_file_path /path/to/drb-ablation-s2.jsonl \
-    --task_name drb-abaltion-s2 \
+    --task_name drb-ablation-s2 \
     --drb_repo_path /path/to/deep_research_bench
 ```
 
-### 3. Step up the original GitHub Repo
-
-#### 3.1. Prerequisites
-
-- Python 3.9+
-- Gemini API key (for LLM evaluation)
-- Jina API key (for web scraping in FACT evaluation)
-
-#### 3.2. Set up and create a new environment
+### 3. Set up the external repo
 
 ```bash
 git clone https://github.com/Ayanami0730/deep_research_bench
@@ -44,42 +103,16 @@ conda activate drb
 pip install -r requirements.txt
 ```
 
-🚨 **Crucial**: The original citation evaluation model is deprecated, go to `/path/to/deep_research_bench/utils/api.py` of the repo and change the `FACT_Moedel` to `gemini-2.5-flash-preview-09-2025` to avoid errors in citation evaluation.
-
-#### 3.3 API Configuration
-
-Set the required API keys as environment variables:
+🚨 **Crucial**: Change `FACT_Moedel` in `utils/api.py` to `gemini-2.5-flash-preview-09-2025`.
 
 ```bash
-# Set Gemini API key for LLM evaluation
 export GEMINI_API_KEY="your_gemini_api_key_here"
-
-# Set Jina API key for web scraping
 export JINA_API_KEY="your_jina_api_key_here"
 ```
 
-#### 1.4 Quick format guide (in the DRB repo)
-- Original query file: `data/prompt_data/query.jsonl`
-- Example output file: `data/test_data/raw_data/claude-3-7-sonnet-latest.jsonl`
-
-
-### 4. Run the evaluation and acquire the results
-
-#### 4.1. Configure the task to evaluate
-- After the setup of the original repository, copy our eval script (`run_benchmark_scraped.sh`) in this folder to the root directory of repository folder
-
-- Edit `run_benchmark_scraped.sh` and add your `task_name` (as you specified in Step 2):
-
-```bash
-TARGET_MODELS=("drb-abaltion-s2")
-```
-
-#### 4.2. Run the evaluation
-Run the evaluation under the DRB repo folder and the corresponding environment.
+### 4. Run evaluation
+Copy `run_benchmark_scraped.sh` to the DRB repo root, edit `TARGET_MODELS`, and run:
 ```bash
 bash run_benchmark_scraped.sh
 ```
-The evaluation will take around 40 minutes. You can check the progress in `output_$task_name.log`.
-
-#### 4.3. Check the results
-By default, your RACE scores (for the article) will be scored in `output_$task_name.log` in the root directory of repository folder. Your FACT scores (for the citations) will be scored in `results/fact/$task_name/fact_result.txt` under the repository folder
+Results: RACE in `output_<task>.log`, FACT in `results/fact/<task>/fact_result.txt`.

--- a/agent/evaluation/deep_research_bench_eval/README.md
+++ b/agent/evaluation/deep_research_bench_eval/README.md
@@ -13,7 +13,7 @@ The self-contained script `run_eval.py` bundles all evaluation code and data. **
 ### Prerequisites
 
 ```bash
-pip install google-genai tqdm
+pip install google-genai tqdm huggingface_hub
 export GEMINI_API_KEY="your_gemini_api_key_here"
 ```
 
@@ -69,12 +69,10 @@ python scripts/evaluate.py deep_research_bench eval_output/auto_search_sft/deep_
 
 ### Evaluation Data
 
-Data files are automatically downloaded from [rl-research/dr-tulu-eval-data](https://huggingface.co/datasets/rl-research/dr-tulu-eval-data) on HuggingFace:
+The following data files are hosted at [`rl-research/dr-tulu-eval-data`](https://huggingface.co/datasets/rl-research/dr-tulu-eval-data) and **auto-downloaded on first run**:
 - `query.jsonl` — 100 evaluation queries (50 EN + 50 ZH)
 - `criteria.jsonl` — Task-specific evaluation criteria with weights
-- `reference.jsonl` — Reference articles for comparison (from Claude 3.7 Sonnet)
-
-If you prefer local files, place them in `data/` with the original directory structure and they will be used instead.
+- `reference.jsonl` — Reference articles for comparison (from the original DRB repo)
 
 ---
 

--- a/agent/evaluation/deep_research_bench_eval/run_eval.py
+++ b/agent/evaluation/deep_research_bench_eval/run_eval.py
@@ -1,0 +1,1659 @@
+#!/usr/bin/env python3
+"""
+Self-contained Deep Research Bench (DRB) evaluation script.
+
+Runs both RACE (article quality) and FACT (citation verification) evaluations
+without requiring the external deep_research_bench repository.
+
+Usage:
+    # Full pipeline: format + RACE + FACT
+    python run_eval.py --input_file <path/to/drb_output.jsonl> --task_name <name>
+
+    # Only RACE evaluation (skip FACT)
+    python run_eval.py --input_file <path/to/drb_output.jsonl> --task_name <name> --skip_fact
+
+    # Only FACT evaluation (skip RACE)
+    python run_eval.py --input_file <path/to/drb_output.jsonl> --task_name <name> --skip_race
+
+    # With options
+    python run_eval.py --input_file <path/to/drb_output.jsonl> --task_name <name> \
+        --max_workers 10 --only_en --limit 5
+
+Environment Variables Required:
+    GEMINI_API_KEY: Google Gemini API key (for both RACE and FACT evaluation)
+
+Data files (bundled in data/ subdirectory):
+    - data/prompt_data/query.jsonl
+    - data/criteria_data/criteria.jsonl
+    - data/test_data/cleaned_data/reference.jsonl
+"""
+
+import argparse
+import concurrent.futures
+import json
+import logging
+import os
+import re
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# ============================================================================
+# Logging setup
+# ============================================================================
+logging.basicConfig(
+    level=logging.WARNING, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# ============================================================================
+# Constants
+# ============================================================================
+SCRIPT_DIR = Path(__file__).parent
+DATA_DIR = SCRIPT_DIR / "data"
+HF_EVAL_DATA_REPO = "rl-research/dr-tulu-eval-data"
+MAX_RETRIES = 10
+
+# Gemini model configuration
+FACT_MODEL = "gemini-2.5-flash"
+RACE_MODEL = "gemini-2.5-pro"
+
+
+def _get_data_file(hf_filename: str, local_fallback: Path) -> str:
+    """Get a data file path: try local first, then download from HuggingFace."""
+    if local_fallback.exists():
+        return str(local_fallback)
+    try:
+        from huggingface_hub import hf_hub_download
+        path = hf_hub_download(
+            repo_id=HF_EVAL_DATA_REPO,
+            filename=hf_filename,
+            repo_type="dataset",
+        )
+        logger.info(f"Downloaded {hf_filename} from {HF_EVAL_DATA_REPO}")
+        return path
+    except Exception as e:
+        raise FileNotFoundError(
+            f"Data file not found locally at {local_fallback} and failed to download "
+            f"from {HF_EVAL_DATA_REPO}/{hf_filename}: {e}\n"
+            f"Install huggingface_hub: pip install huggingface_hub"
+        )
+
+
+def get_criteria_file() -> str:
+    return _get_data_file(
+        "deep_research_bench/criteria.jsonl",
+        DATA_DIR / "criteria_data" / "criteria.jsonl",
+    )
+
+def get_reference_file() -> str:
+    return _get_data_file(
+        "deep_research_bench/reference.jsonl",
+        DATA_DIR / "test_data" / "cleaned_data" / "reference.jsonl",
+    )
+
+def get_query_file() -> str:
+    return _get_data_file(
+        "deep_research_bench/query.jsonl",
+        DATA_DIR / "prompt_data" / "query.jsonl",
+    )
+
+
+# ============================================================================
+# Utility functions
+# ============================================================================
+def load_jsonl(file_path: str) -> list:
+    """Load a JSONL file and return a list of dictionaries."""
+    data = []
+    with open(file_path, "r", encoding="utf-8") as f:
+        for line in f.readlines():
+            if line.strip():
+                data.append(json.loads(line.strip()))
+    return data
+
+
+def extract_json_from_markdown(text: str) -> Optional[str]:
+    """Extract JSON from a markdown text that may contain ```json ... ``` blocks."""
+    if not isinstance(text, str):
+        return None
+
+    # Method 0: Direct JSON object
+    if text.strip().startswith("{") and text.strip().endswith("}"):
+        try:
+            json.loads(text.strip())
+            return text.strip()
+        except json.JSONDecodeError:
+            pass
+
+    # Method 1: Code block extraction
+    if "```json" in text and "```" in text[text.find("```json") + 7 :]:
+        start = text.find("```json") + 7
+        end = text.find("```", start)
+        if end > start:
+            json_str = text[start:end].strip()
+            try:
+                json.loads(json_str)
+                return json_str
+            except json.JSONDecodeError:
+                pass
+
+    # Method 2: Regex matching
+    match = re.search(r"```json\s*([\s\S]*?)\s*```", text)
+    if match:
+        json_str = match.group(1).strip()
+        try:
+            json.loads(json_str)
+            return json_str
+        except json.JSONDecodeError:
+            pass
+
+    # Method 3: Full text as JSON
+    try:
+        json.loads(text.strip())
+        return text.strip()
+    except json.JSONDecodeError:
+        pass
+
+    # Method 4: Outermost curly braces
+    start = text.find("{")
+    if start != -1:
+        level = 0
+        for i, char in enumerate(text[start:]):
+            if char == "{":
+                level += 1
+            elif char == "}":
+                level -= 1
+                if level == 0:
+                    end = start + i + 1
+                    potential_json = text[start:end]
+                    try:
+                        json.loads(potential_json)
+                        return potential_json
+                    except json.JSONDecodeError:
+                        pass
+                    break
+
+    # Method 5: First/last brace matching
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        potential_json = text[start : end + 1]
+        try:
+            json.loads(potential_json)
+            return potential_json
+        except json.JSONDecodeError:
+            pass
+
+    # Method 6: Keyword pattern matching fallback
+    if (
+        "comprehensiveness" in text
+        and "article_1_score" in text
+        and "article_2_score" in text
+    ):
+        try:
+            dimensions = [
+                "comprehensiveness",
+                "insight",
+                "instruction_following",
+                "readability",
+            ]
+            result = {}
+            for dim in dimensions:
+                if dim in text:
+                    result[dim] = []
+                    dim_start = text.find(f'"{dim}"')
+                    if dim_start == -1:
+                        dim_start = text.find(f"'{dim}'")
+                    if dim_start == -1:
+                        dim_start = text.find(dim)
+                    if dim_start != -1:
+                        next_dim_start = len(text)
+                        for next_dim in dimensions:
+                            if next_dim != dim:
+                                pos = text.find(f'"{next_dim}"', dim_start)
+                                if pos == -1:
+                                    pos = text.find(f"'{next_dim}'", dim_start)
+                                if pos == -1:
+                                    pos = text.find(next_dim, dim_start + len(dim))
+                                if pos != -1 and pos < next_dim_start:
+                                    next_dim_start = pos
+                        dim_content = text[dim_start:next_dim_start]
+                        criterion_matches = re.finditer(
+                            r'"criterion"\s*:\s*"([^"]+)"', dim_content
+                        )
+                        score1_matches = re.finditer(
+                            r'"article_1_score"\s*:\s*(\d+\.?\d*)', dim_content
+                        )
+                        score2_matches = re.finditer(
+                            r'"article_2_score"\s*:\s*(\d+\.?\d*)', dim_content
+                        )
+                        criteria = [m.group(1) for m in criterion_matches]
+                        scores1 = [float(m.group(1)) for m in score1_matches]
+                        scores2 = [float(m.group(1)) for m in score2_matches]
+                        for i in range(min(len(criteria), len(scores1), len(scores2))):
+                            result[dim].append(
+                                {
+                                    "criterion": criteria[i],
+                                    "article_1_score": scores1[i],
+                                    "article_2_score": scores2[i],
+                                }
+                            )
+            if any(len(scores) > 0 for scores in result.values()):
+                return json.dumps(result)
+        except Exception:
+            pass
+
+    return None
+
+
+def contains_chinese(text: str) -> bool:
+    """Check if a string contains Chinese characters."""
+    return re.search(r"[\u4e00-\u9fff]", text) is not None
+
+
+# ============================================================================
+# Gemini API Client
+# ============================================================================
+class GeminiClient:
+    """Client for calling Gemini API."""
+
+    def __init__(self, api_key: str = None, model: str = RACE_MODEL):
+        try:
+            from google import genai
+            from google.genai import types
+        except ImportError:
+            raise ImportError(
+                "google-genai package required. Install with: pip install google-genai"
+            )
+
+        self.api_key = api_key or os.environ.get("GEMINI_API_KEY", "")
+        if not self.api_key:
+            raise ValueError(
+                "Gemini API key not provided. Set GEMINI_API_KEY environment variable."
+            )
+
+        self.client = genai.Client(
+            api_key=self.api_key, http_options={"timeout": 600000}
+        )
+        self.model = model
+        self._genai = genai
+        self._types = types
+
+    def generate(
+        self,
+        user_prompt: str,
+        system_prompt: str = "",
+        model: str = None,
+    ) -> str:
+        """Generate text response from Gemini."""
+        model_to_use = model or self.model
+        contents = []
+        if system_prompt:
+            contents.append({"role": "system", "parts": [{"text": system_prompt}]})
+        contents.append({"role": "user", "parts": [{"text": user_prompt}]})
+
+        response = self.client.models.generate_content(
+            model=model_to_use,
+            contents=contents,
+            config=self._types.GenerateContentConfig(
+                thinking_config=self._types.ThinkingConfig(thinking_budget=16000)
+            ),
+        )
+        return response.text
+
+
+# ============================================================================
+# Scoring prompts (English)
+# ============================================================================
+SCORE_PROMPT_EN = """
+<system_role>You are a strict, meticulous, and objective research article evaluation expert. You excel at using specific assessment criteria to deeply compare two articles on the same task, providing precise scores and clear justifications.</system_role>
+
+<user_prompt>
+**Task Background**
+There is a deep research task, and you need to evaluate two research articles written for this task. We will assess the articles across four dimensions: Comprehensiveness, Insight, Instruction Following, and Readability. The content is as follows:
+<task>
+"{task_prompt}"
+</task>
+
+**Articles to Evaluate**
+<article_1>
+"{article_1}"
+</article_1>
+
+<article_2>
+"{article_2}"
+</article_2>
+
+**Evaluation Criteria**
+Now, you need to evaluate and compare these two articles based on the following **evaluation criteria list**, providing comparative analysis and scoring each on a scale of 0-10. Each criterion includes an explanation, please understand carefully.
+
+<criteria_list>
+{criteria_list}
+</criteria_list>
+
+<Instruction>
+**Your Task**
+Please strictly evaluate and compare `<article_1>` and `<article_2>` based on **each criterion** in the `<criteria_list>`. You need to:
+1.  **Analyze Each Criterion**: Consider how each article fulfills the requirements of each criterion.
+2.  **Comparative Evaluation**: Analyze how the two articles perform on each criterion, referencing the content and criterion explanation.
+3.  **Score Separately**: Based on your comparative analysis, score each article on each criterion (0-10 points).
+
+**Scoring Rules**
+For each criterion, score both articles on a scale of 0-10 (continuous values). The score should reflect the quality of performance on that criterion:
+*   0-2 points: Very poor performance.
+*   2-4 points: Poor performance.
+*   4-6 points: Average performance.
+*   6-8 points: Good performance.
+*   8-10 points: Excellent/outstanding performance.
+
+**Output Format Requirements**
+Please **strictly** follow the `<output_format>` below for each criterion evaluation.
+</Instruction>
+
+<output_format>
+{{
+    "comprehensiveness": [
+        {{
+            "criterion": [Text content of the first comprehensiveness evaluation criterion],
+            "analysis": [Comparative analysis],
+            "article_1_score": [Continuous score 0-10],
+            "article_2_score": [Continuous score 0-10]
+        }},
+        ...
+    ],
+    "insight": [...],
+    "instruction_following": [...],
+    "readability": [...]
+}}
+</output_format>
+
+Now, please evaluate the two articles. Ensure your output follows the specified format and that the JSON format is parsable.
+</user_prompt>
+"""
+
+# ============================================================================
+# Scoring prompts (Chinese)
+# ============================================================================
+SCORE_PROMPT_ZH = """
+<system_role>你是一名严格、细致、客观的调研文章评估专家。你擅长根据具体的评估标准，深入比较两篇针对同一任务的文章，并给出精确的评分和清晰的理由。</system_role>
+
+<user_prompt>
+**任务背景**
+有一个深度调研任务，你需要评估针对该任务撰写的两篇调研文章。我们会从以下四个维度评估文章：全面性、洞察力、指令遵循能力和可读性。内容如下：
+<task>
+"{task_prompt}"
+</task>
+
+**待评估文章**
+<article_1>
+"{article_1}"
+</article_1>
+
+<article_2>
+"{article_2}"
+</article_2>
+
+**评估标准**
+现在，你需要根据以下**评判标准列表**，逐条评估并比较这两篇文章的表现，输出对比分析，然后给出0-10的分数。
+
+<criteria_list>
+{criteria_list}
+</criteria_list>
+
+<Instruction>
+**你的任务**
+请严格按照 `<criteria_list>` 中的**每一条标准**，对比评估 `<article_1>` 和 `<article_2>`。
+1. 逐条分析
+2. 对比评估
+3. 分别打分（0-10分）
+
+**输出格式要求**
+请**严格**按照下列格式输出：
+</Instruction>
+
+<output_format>
+{{
+    "comprehensiveness": [
+        {{
+            "criterion": [评判标准文本],
+            "analysis": [对比分析],
+            "article_1_score": [0-10连续分数],
+            "article_2_score": [0-10连续分数]
+        }},
+        ...
+    ],
+    "insight": [...],
+    "instruction_following": [...],
+    "readability": [...]
+}}
+</output_format>
+
+请确保输出格式遵守上述要求，且JSON格式可解析。
+</user_prompt>
+"""
+
+# ============================================================================
+# Article cleaning prompts
+# ============================================================================
+CLEAN_PROMPT_EN = """
+<system_role>You are a professional article editor who is good at cleaning and refining article content.</system_role>
+
+<user_prompt>
+Please help me clean the following research article, removing all citation links, citation marks (such as [1], [2], 1, 2, etc. or other complex citation formats), reference lists, footnotes, and ensuring the content is coherent and smooth.
+Keep all other original content of the article, removing only the citations. If the content of the citation mark is used as part of a sentence in the article, keep the text content and remove other marks.
+
+Article content:
+"{article}"
+
+Please return the cleaned article in full, without adding any additional comments or explanations.
+</user_prompt>
+"""
+
+CLEAN_PROMPT_ZH = """
+<system_role>你是一名专业的文章编辑，擅长整理和清洗文章内容。</system_role>
+
+<user_prompt>
+请帮我清洗以下研究文章，去除所有引用链接、引用标记（如[1]、[2]、1、2 等或其他复杂引用格式）、参考文献列表、脚注，并确保文章内容连贯流畅。
+保留文章的所有其他原本内容、只移除引用。如果文章中使用引用标记中的内容作为语句的一部分，保留这其中的文字内容，移除其他标记。
+
+文章内容：
+"{article}"
+
+请返回清洗后的文章全文，不要添加任何额外说明或评论。
+</user_prompt>
+"""
+
+# ============================================================================
+# FACT validation prompts
+# ============================================================================
+FACT_VALIDATE_PROMPT_EN = """You will be provided with a reference and some statements. Please determine whether each statement is 'supported', 'unsupported', or 'unknown' with respect to the reference. Please note:
+First, assess whether the reference contains any valid content. If the reference contains no valid information, such as a 'page not found' message, then all statements should be considered 'unknown'.
+If the reference is valid, for a given statement: if the facts or data it contains can be found entirely or partially within the reference, it is considered 'supported' (data accepts rounding); if all facts and data in the statement cannot be found in the reference, it is considered 'unsupported'.
+
+You should return the result in a JSON list format, where each item in the list contains the statement's index and the judgment result, for example:
+[
+    {{
+        "idx": 1,
+        "result": "supported"
+    }},
+    {{
+        "idx": 2,
+        "result": "unsupported"
+    }}
+]
+
+Below are the reference and statements:
+<reference>
+{reference}
+</reference>
+
+<statements>
+{statements}
+</statements>
+
+Begin the assessment now. Output only the JSON list, without any conversational text or explanations."""
+
+FACT_VALIDATE_PROMPT_ZH = """你会看到一个参考资料和一些statement，请你判断对于参考资料来说statement是supported、unsupported、或者unknown，注意：
+首先判断参考资料是否存在有效内容，如果参考资料中没有任何有效信息，如"page not found"页面，则认为所有statement的状态都是unknown。
+除此之外，参考资料有效的情况下，对于一个statement来说，如果它包含的事实或数据在参考资料中可以全部或部分找到，就认为它是supported的（数据接受四舍五入）；如果statement中所有的事实和数据在参考资料中都找不到，认为它是unsupported的。
+
+你应该返回json列表格式，列表中的每一项包含statement的序号和判断结果，例如：
+[
+    {{
+        "idx": 1,
+        "result": "supported"
+    }},
+    {{
+        "idx": 2,
+        "result": "unsupported"
+    }}
+]
+
+下面是参考资料和statements：
+<reference>
+{reference}
+</reference>
+
+<statements>
+{statements}
+</statements>
+
+下面开始判断，直接输出json列表，不要输出任何闲聊或解释。"""
+
+
+# ============================================================================
+# Score Calculator
+# ============================================================================
+def calculate_weighted_scores(
+    llm_output_json: dict, criteria_data: dict, language: str = "en"
+) -> dict:
+    """Calculate weighted scores based on LLM output and criteria weights."""
+    results = {
+        "target": {"dims": {}, "total": 0.0},
+        "reference": {"dims": {}, "total": 0.0},
+    }
+    total_target_score = 0.0
+    total_reference_score = 0.0
+
+    dimension_weights = criteria_data.get("dimension_weight", {})
+    task_id = criteria_data.get("id", "Unknown")
+
+    if "criterions" not in criteria_data or not criteria_data["criterions"]:
+        raise ValueError(
+            f"ID: {task_id} - Missing required criterions data"
+        )
+
+    criterion_weights = {}
+    for dim, criterions in criteria_data.get("criterions", {}).items():
+        criterion_weights[dim] = {
+            crit["criterion"]: crit["weight"] for crit in criterions
+        }
+
+    for dim, scores_list in llm_output_json.items():
+        if not isinstance(scores_list, list):
+            continue
+        if dim not in dimension_weights or dim not in criterion_weights:
+            continue
+
+        dim_target_weighted_sum = 0.0
+        dim_reference_weighted_sum = 0.0
+        dim_total_weight = 0.0
+        dim_criteria_map = criterion_weights.get(dim, {})
+        if not dim_criteria_map:
+            continue
+
+        article_2_score = None
+        for score_item in scores_list:
+            if not isinstance(score_item, dict):
+                continue
+
+            criterion_text_raw = score_item.get("criterion")
+            criterion_text = (
+                criterion_text_raw.strip()
+                if isinstance(criterion_text_raw, str)
+                else None
+            )
+
+            article_1_score_raw = score_item.get("article_1_score")
+            article_2_score_raw = score_item.get("article_2_score")
+            target_score_raw = score_item.get("target_score")
+
+            if target_score_raw is not None and article_1_score_raw is None:
+                article_1_score_raw = target_score_raw
+
+            try:
+                article_1_score = (
+                    float(article_1_score_raw)
+                    if article_1_score_raw is not None
+                    else None
+                )
+                article_2_score = (
+                    float(article_2_score_raw)
+                    if article_2_score_raw is not None
+                    else None
+                )
+            except (ValueError, TypeError):
+                continue
+
+            if criterion_text and article_1_score is not None:
+                weight = dim_criteria_map.get(criterion_text)
+
+                # Fuzzy matching
+                if weight is None:
+                    criterion_lower = criterion_text.lower()
+                    for key, val in dim_criteria_map.items():
+                        if key.lower() == criterion_lower:
+                            weight = val
+                            break
+                    if weight is None:
+                        for key, val in dim_criteria_map.items():
+                            if (
+                                criterion_lower in key.lower()
+                                or key.lower() in criterion_lower
+                            ):
+                                weight = val
+                                break
+
+                if weight is None:
+                    weight = sum(dim_criteria_map.values()) / len(dim_criteria_map)
+
+                dim_target_weighted_sum += article_1_score * weight
+                dim_total_weight += weight
+                if article_2_score is not None:
+                    dim_reference_weighted_sum += article_2_score * weight
+
+        if dim_total_weight > 0:
+            dim_target_avg = dim_target_weighted_sum / dim_total_weight
+            dim_reference_avg = (
+                dim_reference_weighted_sum / dim_total_weight
+                if article_2_score is not None
+                else 0
+            )
+        else:
+            dim_target_avg = 0
+            dim_reference_avg = 0
+
+        results["target"]["dims"][f"{dim}_weighted_avg"] = dim_target_avg
+        results["reference"]["dims"][f"{dim}_weighted_avg"] = dim_reference_avg
+
+        dim_weight = dimension_weights.get(dim, 0)
+        total_target_score += dim_target_avg * dim_weight
+        total_reference_score += dim_reference_avg * dim_weight
+
+    results["target"]["total"] = total_target_score
+    results["reference"]["total"] = total_reference_score
+    return results
+
+
+# ============================================================================
+# Article Cleaner
+# ============================================================================
+class ArticleCleaner:
+    """Clean articles by removing citations and references."""
+
+    def __init__(self, clean_agent: GeminiClient):
+        self.clean_agent = clean_agent
+        self.min_valid_length = 100
+
+    def _clean_text(self, text: str, language: str = "en", max_retries: int = 3) -> Optional[str]:
+        prompt_template = CLEAN_PROMPT_ZH if language == "zh" else CLEAN_PROMPT_EN
+        user_prompt = prompt_template.format(article=text)
+
+        for retry in range(max_retries):
+            try:
+                result = self.clean_agent.generate(user_prompt=user_prompt, system_prompt="")
+                if result and len(result.strip()) >= self.min_valid_length:
+                    return result
+            except Exception as e:
+                logger.error(f"API call error: {e}")
+                error_str = str(e).lower()
+                if "tokens" in error_str and "less than" in error_str:
+                    return None
+        return None
+
+    def chunk_clean_article(self, article: str, language: str = "en") -> Optional[str]:
+        """Split long article into two chunks for processing."""
+        logger.info("Attempting to process article in 2 chunks")
+        chunk_size = len(article) // 2
+        chunks = []
+
+        # First chunk: split at sentence boundary
+        end = chunk_size
+        search_start = max(0, end - 200)
+        for j in range(end, search_start, -1):
+            if j < len(article) and article[j] in ".?!。？！\n":
+                end = j + 1
+                break
+        chunks.append(article[:end])
+        chunks.append(article[end:])
+
+        cleaned_chunks = []
+        for i, chunk in enumerate(chunks):
+            clean_result = self._clean_text(chunk, language)
+            if clean_result is None and len(chunk) > 200000:
+                return None
+            cleaned_chunks.append(clean_result or "")
+
+        return "".join(cleaned_chunks)
+
+    def clean_single(
+        self,
+        item: dict,
+        output_file: str = None,
+        processed_ids: set = None,
+        file_lock=None,
+        pbar_lock=None,
+        pbar=None,
+        max_retries: int = 5,
+        language: str = "en",
+    ):
+        """Clean a single article."""
+        try:
+            data = item.copy()
+            item_id = data.get("id")
+            prompt = data.get("prompt", "")
+            article = data.get("article", "")
+
+            if not item_id or not prompt or not article:
+                if pbar and pbar_lock:
+                    with pbar_lock:
+                        pbar.update(1)
+                return None
+
+            if processed_ids is not None and item_id in processed_ids:
+                if pbar and pbar_lock:
+                    with pbar_lock:
+                        pbar.update(1)
+                return None
+
+            cleaned_article = self._clean_text(article, language, max_retries)
+            if cleaned_article is None:
+                cleaned_article = self.chunk_clean_article(article, language=language)
+
+            if not cleaned_article or len(cleaned_article.strip()) < self.min_valid_length:
+                if pbar and pbar_lock:
+                    with pbar_lock:
+                        pbar.update(1)
+                return {"id": item_id, "error": "Failed to clean article"}
+
+            result = {"id": item_id, "prompt": prompt, "article": cleaned_article}
+
+            if output_file and file_lock and processed_ids is not None:
+                with file_lock:
+                    with open(output_file, "a", encoding="utf-8") as f:
+                        f.write(json.dumps(result, ensure_ascii=False) + "\n")
+                    processed_ids.add(item_id)
+                if pbar and pbar_lock:
+                    with pbar_lock:
+                        pbar.update(1)
+                return item_id
+            else:
+                if pbar and pbar_lock:
+                    with pbar_lock:
+                        pbar.update(1)
+                return result
+
+        except Exception as e:
+            if pbar and pbar_lock:
+                with pbar_lock:
+                    pbar.update(1)
+            logger.error(f"Error cleaning article {item.get('id', 'unknown')}: {e}")
+            return None
+
+    def clean_articles(
+        self,
+        model_name: str,
+        raw_data_dir: str,
+        cleaned_data_dir: str,
+        max_workers: int = 5,
+        max_retries: int = 5,
+        limit: int = None,
+        language: str = "en",
+    ):
+        """Clean articles for a model."""
+        from tqdm import tqdm
+
+        os.makedirs(cleaned_data_dir, exist_ok=True)
+        input_file = os.path.join(raw_data_dir, f"{model_name}.jsonl")
+        output_file = os.path.join(cleaned_data_dir, f"{model_name}.jsonl")
+
+        if not os.path.exists(input_file):
+            logger.warning(f"Input file not found: {input_file}")
+            return
+
+        logger.info(f"=== Cleaning {model_name} articles ===")
+
+        # Load input data
+        all_items = []
+        with open(input_file, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    try:
+                        all_items.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        pass
+
+        if limit is not None and limit > 0:
+            all_items = all_items[:limit]
+
+        # Load processed IDs
+        processed_ids = set()
+        if os.path.exists(output_file):
+            with open(output_file, "r", encoding="utf-8") as f:
+                for line in f:
+                    if line.strip():
+                        try:
+                            data = json.loads(line)
+                            if "id" in data:
+                                processed_ids.add(data["id"])
+                        except json.JSONDecodeError:
+                            pass
+
+        to_process = [
+            item for item in all_items if item.get("id") not in processed_ids
+        ]
+        logger.info(
+            f"Total: {len(all_items)}, to process: {len(to_process)}, already done: {len(processed_ids)}"
+        )
+
+        if not to_process:
+            logger.info("All items already processed.")
+            return
+
+        file_lock = threading.Lock()
+        pbar_lock = threading.Lock()
+
+        with tqdm(
+            total=len(all_items),
+            desc=f"Cleaning {model_name}",
+            initial=len(processed_ids),
+        ) as pbar:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=max_workers
+            ) as executor:
+                futures = [
+                    executor.submit(
+                        self.clean_single,
+                        item,
+                        output_file,
+                        processed_ids,
+                        file_lock,
+                        pbar_lock,
+                        pbar,
+                        max_retries,
+                        language,
+                    )
+                    for item in to_process
+                ]
+                for future in concurrent.futures.as_completed(futures):
+                    future.result()
+
+
+# ============================================================================
+# DRB Formatter (from drb_formatter.py)
+# ============================================================================
+def parse_xml_snippets(text: str) -> dict:
+    """Parse XML-like snippets into a dictionary."""
+    pattern = re.compile(
+        r"<snippet id=([^>]+)>"
+        r"\s*Title: (.*?)"
+        r"\s*(?:URL: (.*?))?"
+        r"\s*Snippet: (.*?)"
+        r"\s*</snippet>",
+        re.DOTALL,
+    )
+    matches = pattern.findall(text)
+    results = {}
+    for match in matches:
+        snippet_id = match[0].strip()
+        title = match[1].strip()
+        url = match[2].strip() if match[2] else ""
+        snippet = match[3].strip()
+        results[snippet_id] = {"Title": title, "URL": url, "Snippet": snippet}
+    return results
+
+
+def parse_and_format_citations(text: str):
+    """Parse <cite> tags and reformat the string."""
+    citation_ids = []
+    id_to_text_map = {}
+
+    def replacer(match):
+        ids_string = match.group(1)
+        text_content = match.group(2)
+        ids = ids_string.split(",")
+        for this_id in ids:
+            if this_id not in citation_ids:
+                citation_ids.append(this_id)
+        for cid in ids:
+            if cid not in id_to_text_map:
+                id_to_text_map[cid] = [text_content]
+            else:
+                id_to_text_map[cid].append(text_content)
+        formatted_ids = " ".join([f"[{id}]" for id in ids])
+        return f". {text_content} {formatted_ids}."
+
+    pattern = re.compile(r'<cite id="([^"]+)">([^<]+)</cite>')
+    formatted_text = pattern.sub(replacer, text)
+    return formatted_text, citation_ids, id_to_text_map
+
+
+def parse_search_results(text: str) -> list:
+    """Parse search results from text."""
+    pattern = re.compile(
+        r"Title: (.*?)\n"
+        r"(?:URL: (.*?)\n)?"
+        r"Snippet: (.*?)"
+        r"(?=\nTitle: |\Z)",
+        re.DOTALL,
+    )
+    matches = pattern.findall(text)
+    results = []
+    for match in matches:
+        results.append(
+            {
+                "Title": match[0].strip(),
+                "URL": match[1].strip(),
+                "Snippet": match[2].strip(),
+            }
+        )
+    return results
+
+
+def format_drb_data(example: dict) -> dict:
+    """Convert a single example to DRB format."""
+    output = {}
+    output["id"] = example.get("example_id", example.get("id"))
+    output["prompt"] = example["problem"]
+    output["article"] = ""
+    output["citations_deduped"] = {}
+    output["citations"] = []
+
+    traces = {}
+    all_urls = {}
+    if "full_traces" in example:
+        for call in example["full_traces"]["tool_calls"]:
+            if "call_id" in call:
+                call_id = call["call_id"]
+                call_results = parse_search_results(call["output"])
+                if len(call_results) == 0:
+                    try:
+                        aggregated_results = "\n\n".join(
+                            raw_call["output"].strip()
+                            for raw_call in call["raw_output"]["tool_outputs"]
+                        )
+                        call_results = parse_search_results(aggregated_results)
+                    except Exception:
+                        pass
+
+                for i, each_result in enumerate(call_results):
+                    traces[call_id + "-" + str(i)] = each_result
+                    all_urls[each_result["URL"]] = call_id + "-" + str(i)
+            else:
+                snippets = parse_xml_snippets(call["generated_text"])
+                for snippet_id, snippet_content in snippets.items():
+                    traces[snippet_id] = snippet_content
+                    all_urls[snippet_content["URL"]] = snippet_id
+
+    if "final_response" not in example:
+        if "pred_answer" in example:
+            example["final_response"] = example["pred_answer"]
+
+    article, citation_ids, id_to_text_map = parse_and_format_citations(
+        example["final_response"]
+    )
+
+    for url, cid in all_urls.items():
+        if cid in id_to_text_map:
+            output["citations_deduped"][url] = {
+                "facts": id_to_text_map[cid],
+                "url_content": traces[cid]["Title"] + "\n\n" + traces[cid]["Snippet"],
+            }
+            for fact in id_to_text_map[cid]:
+                output["citations"].append(
+                    {"fact": fact, "ref_indx": cid, "url": url}
+                )
+
+    reference = []
+    for i, each_id in enumerate(citation_ids):
+        if each_id in traces:
+            reference.append("[" + str(i + 1) + "] " + traces[each_id]["URL"])
+            article = article.replace(each_id, str(i + 1))
+        else:
+            indicator = False
+            for each_url in all_urls:
+                if each_id in each_url:
+                    reference.append("[" + str(i + 1) + "] " + each_url)
+                    article = article.replace(each_id, str(i + 1))
+                    indicator = True
+                    break
+            if not indicator:
+                article = article.replace("[" + each_id + "]", "")
+
+    if contains_chinese(article):
+        output["article"] = article + "\n\n 参考文献: " + "\n".join(reference)
+    else:
+        output["article"] = article + "\n\n References: " + "\n".join(reference)
+
+    return output
+
+
+def run_format_conversion(input_file: str, task_name: str, output_dir: str) -> tuple:
+    """
+    Run format conversion for DRB evaluation.
+
+    Returns:
+        (raw_data_path, scraped_data_path): Paths to the formatted output files
+    """
+    data = load_jsonl(input_file)
+
+    raw_data_dir = os.path.join(output_dir, "raw_data")
+    scrape_dir = os.path.join(output_dir, "fact", task_name)
+    os.makedirs(raw_data_dir, exist_ok=True)
+    os.makedirs(scrape_dir, exist_ok=True)
+
+    formatted_data = []
+    for i, item in enumerate(data):
+        try:
+            formatted_data.append(format_drb_data(item))
+        except Exception:
+            logger.warning(f"Error formatting data point {i}")
+
+    raw_data_path = os.path.join(raw_data_dir, f"{task_name}.jsonl")
+    with open(raw_data_path, "w", encoding="utf-8") as f:
+        for item in formatted_data:
+            f.write(json.dumps(item) + "\n")
+
+    scraped_data_path = os.path.join(scrape_dir, "scraped.jsonl")
+    with open(scraped_data_path, "w", encoding="utf-8") as f:
+        for item in formatted_data:
+            f.write(json.dumps(item) + "\n")
+
+    logger.info(f"Formatted {len(formatted_data)} items -> {raw_data_path}")
+    return raw_data_path, scraped_data_path
+
+
+# ============================================================================
+# RACE Evaluation
+# ============================================================================
+def format_criteria_list(criteria_data: dict) -> str:
+    """Format evaluation criteria list as JSON string."""
+    criteria_for_prompt = {}
+    criterions_dict = criteria_data.get("criterions", {})
+    for dim, criterions_list in criterions_dict.items():
+        if not isinstance(criterions_list, list):
+            continue
+        criteria_for_prompt[dim] = []
+        for crit_item in criterions_list:
+            if isinstance(crit_item, dict) and "criterion" in crit_item and "explanation" in crit_item:
+                criteria_for_prompt[dim].append(
+                    {
+                        "criterion": crit_item["criterion"],
+                        "explanation": crit_item["explanation"],
+                    }
+                )
+    return json.dumps(criteria_for_prompt, ensure_ascii=False, indent=2)
+
+
+def process_single_race_item(
+    task_data,
+    target_articles_map,
+    reference_articles_map,
+    criteria_map,
+    llm_client,
+    lock,
+    pbar,
+    max_retries,
+    language,
+):
+    """Process a single RACE evaluation item."""
+    task_id = task_data.get("id")
+    prompt = task_data.get("prompt")
+
+    if prompt not in target_articles_map:
+        with lock:
+            pbar.update(1)
+        return {"id": task_id, "prompt": prompt, "error": "Target article not found"}
+
+    if prompt not in reference_articles_map:
+        with lock:
+            pbar.update(1)
+        return {"id": task_id, "prompt": prompt, "error": "Reference article not found"}
+
+    if prompt not in criteria_map:
+        with lock:
+            pbar.update(1)
+        return {"id": task_id, "prompt": prompt, "error": "Criteria not found"}
+
+    target_article = target_articles_map[prompt].get("article", "")
+    reference_article = reference_articles_map[prompt].get("article", "")
+
+    try:
+        criteria_list_str = format_criteria_list(criteria_map[prompt])
+    except ValueError as e:
+        with lock:
+            pbar.update(1)
+        return {"id": task_id, "prompt": prompt, "error": str(e)}
+
+    score_prompt = SCORE_PROMPT_ZH if language == "zh" else SCORE_PROMPT_EN
+    user_prompt = score_prompt.format(
+        task_prompt=prompt,
+        article_1=target_article,
+        article_2=reference_article,
+        criteria_list=criteria_list_str,
+    )
+
+    llm_response_str = None
+    llm_output_json = None
+    success = False
+    retry_count = 0
+
+    while retry_count < max_retries and not success:
+        try:
+            llm_response_str = llm_client.generate(
+                user_prompt=user_prompt, system_prompt=""
+            )
+            json_str_extracted = extract_json_from_markdown(llm_response_str)
+            if not json_str_extracted:
+                raise ValueError("Failed to extract JSON from LLM response")
+            llm_output_json = json.loads(json_str_extracted)
+            expected_dims = [
+                "comprehensiveness",
+                "insight",
+                "instruction_following",
+                "readability",
+            ]
+            if not all(dim in llm_output_json for dim in expected_dims):
+                missing = [dim for dim in expected_dims if dim not in llm_output_json]
+                raise ValueError(f"Missing dimensions: {missing}")
+            success = True
+        except Exception as e:
+            retry_count += 1
+            if retry_count < max_retries:
+                time.sleep(1.5 ** retry_count)
+            else:
+                logger.error(
+                    f"ID {task_id}: Failed after {max_retries} retries - {str(e)}"
+                )
+
+    if not success:
+        with lock:
+            pbar.update(1)
+        return {
+            "id": task_id,
+            "prompt": prompt,
+            "error": f"Failed after {max_retries} retries",
+        }
+
+    try:
+        scores = calculate_weighted_scores(
+            llm_output_json, criteria_map[prompt], language
+        )
+        target_total = scores["target"]["total"]
+        reference_total = scores["reference"]["total"]
+        overall_score = (
+            target_total / (target_total + reference_total)
+            if target_total + reference_total > 0
+            else 0
+        )
+
+        normalized_dims = {}
+        for dim in [
+            "comprehensiveness",
+            "insight",
+            "instruction_following",
+            "readability",
+        ]:
+            dim_key = f"{dim}_weighted_avg"
+            if dim_key in scores["target"]["dims"]:
+                t = scores["target"]["dims"][dim_key]
+                r = scores["reference"]["dims"][dim_key]
+                normalized_dims[dim] = t / (t + r) if t + r > 0 else 0
+            else:
+                normalized_dims[dim] = 0
+
+    except Exception as e:
+        with lock:
+            pbar.update(1)
+        return {"id": task_id, "prompt": prompt, "error": f"Scoring error: {str(e)}"}
+
+    final_result = {
+        "id": task_id,
+        "prompt": prompt,
+        "comprehensiveness": normalized_dims.get("comprehensiveness", 0),
+        "insight": normalized_dims.get("insight", 0),
+        "instruction_following": normalized_dims.get("instruction_following", 0),
+        "readability": normalized_dims.get("readability", 0),
+        "overall_score": overall_score,
+    }
+
+    with lock:
+        pbar.update(1)
+    return final_result
+
+
+def run_race_evaluation(
+    task_name: str,
+    output_dir: str,
+    llm_client: GeminiClient,
+    max_workers: int = 5,
+    limit: int = None,
+    only_zh: bool = False,
+    only_en: bool = False,
+    force: bool = False,
+    skip_cleaning: bool = False,
+):
+    """Run RACE evaluation."""
+    from tqdm import tqdm
+
+    raw_data_dir = os.path.join(output_dir, "raw_data")
+    cleaned_data_dir = os.path.join(output_dir, "cleaned_data")
+    race_output_dir = os.path.join(output_dir, "race", task_name)
+    os.makedirs(race_output_dir, exist_ok=True)
+    os.makedirs(cleaned_data_dir, exist_ok=True)
+
+    output_file = os.path.join(race_output_dir, "raw_results.jsonl")
+    result_file = os.path.join(race_output_dir, "race_result.txt")
+
+    # Check existing results
+    existing_results = []
+    existing_ids = set()
+    if os.path.exists(output_file) and not force:
+        existing_results = load_jsonl(output_file)
+        existing_ids = {r.get("id") for r in existing_results if r.get("id")}
+        logger.info(f"Found {len(existing_results)} existing results")
+
+    all_results = list(existing_results)
+
+    # Process each language
+    languages = []
+    if not only_en:
+        languages.append("zh")
+    if not only_zh:
+        languages.append("en")
+
+    for language in languages:
+        logger.info(f"Processing {language} data...")
+
+        # Article cleaning
+        if not skip_cleaning:
+            cleaner = ArticleCleaner(llm_client)
+            cleaner.clean_articles(
+                task_name, raw_data_dir, cleaned_data_dir, max_workers, 5, limit, language
+            )
+
+        # Load all data
+        all_tasks = load_jsonl(get_query_file())
+        all_tasks = [t for t in all_tasks if t.get("language") == language]
+        if limit is not None and limit > 0:
+            all_tasks = all_tasks[:limit]
+
+        task_prompts = {t["prompt"] for t in all_tasks if "prompt" in t}
+        all_criteria = load_jsonl(get_criteria_file())
+        criteria_list = [c for c in all_criteria if c.get("prompt") in task_prompts]
+
+        target_file = os.path.join(cleaned_data_dir, f"{task_name}.jsonl")
+        if not os.path.exists(target_file):
+            logger.warning(f"Cleaned target file not found: {target_file}")
+            continue
+
+        all_target = load_jsonl(target_file)
+        target_list = [a for a in all_target if a.get("prompt") in task_prompts]
+        if not target_list:
+            logger.warning(f"No target articles found for {language}")
+            continue
+
+        all_reference = load_jsonl(get_reference_file())
+        reference_list = [a for a in all_reference if a.get("prompt") in task_prompts]
+
+        # Build maps
+        criteria_map = {item["prompt"]: item for item in criteria_list}
+        target_map = {item["prompt"]: item for item in target_list}
+        reference_map = {item["prompt"]: item for item in reference_list}
+
+        tasks_to_process = [
+            t
+            for t in all_tasks
+            if t.get("prompt") in criteria_map
+            and t.get("prompt") in target_map
+            and t.get("prompt") in reference_map
+            and t.get("id") not in existing_ids
+        ]
+
+        if not tasks_to_process:
+            logger.info(f"No tasks to process for {language}")
+            continue
+
+        logger.info(f"Processing {len(tasks_to_process)} {language} tasks...")
+
+        lock = threading.Lock()
+        with tqdm(
+            total=len(tasks_to_process), desc=f"RACE {language} {task_name}"
+        ) as pbar:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=max_workers
+            ) as executor:
+                futures = [
+                    executor.submit(
+                        process_single_race_item,
+                        task,
+                        target_map,
+                        reference_map,
+                        criteria_map,
+                        llm_client,
+                        lock,
+                        pbar,
+                        MAX_RETRIES,
+                        language,
+                    )
+                    for task in tasks_to_process
+                ]
+                for future in concurrent.futures.as_completed(futures):
+                    result = future.result()
+                    if result:
+                        all_results.append(result)
+
+    # Save results
+    if all_results:
+        all_results.sort(key=lambda x: x.get("id", float("inf")))
+        with open(output_file, "w", encoding="utf-8") as f:
+            for result in all_results:
+                f.write(json.dumps(result, ensure_ascii=False) + "\n")
+
+        successful = [r for r in all_results if "error" not in r]
+        if successful:
+            metrics = {}
+            for key in [
+                "comprehensiveness",
+                "insight",
+                "instruction_following",
+                "readability",
+                "overall_score",
+            ]:
+                metrics[key] = sum(r.get(key, 0) for r in successful) / len(successful)
+
+            logger.info("\n=== RACE Evaluation Results ===")
+            for key, val in metrics.items():
+                logger.info(f"  {key}: {val:.4f}")
+            logger.info("================================")
+
+            with open(result_file, "w", encoding="utf-8") as f:
+                for key, val in metrics.items():
+                    f.write(f"{key}: {val:.4f}\n")
+
+            return metrics
+
+    return None
+
+
+# ============================================================================
+# FACT Evaluation
+# ============================================================================
+def validate_single_citation(data: tuple, id_to_lang_map: dict, llm_client: GeminiClient) -> dict:
+    """Validate a single citation against its reference."""
+    url = data[0]
+    ref = data[1]["url_content"]
+    facts = data[1]["facts"]
+    article_id = data[1].get("article_id")
+
+    if ref is None:
+        return {"url": url, "validate_res": [], "error": "no reference"}
+
+    if not article_id or article_id not in id_to_lang_map:
+        return {"url": url, "validate_res": [], "error": "Language not found"}
+
+    lang = id_to_lang_map[article_id]
+    facts_str = "\n".join([f"{i+1}. {fact}" for i, fact in enumerate(facts)])
+
+    if lang == "zh":
+        user_prompt = FACT_VALIDATE_PROMPT_ZH.format(
+            reference=ref, statements=facts_str
+        )
+    else:
+        user_prompt = FACT_VALIDATE_PROMPT_EN.format(
+            reference=ref, statements=facts_str
+        )
+
+    retries = 0
+    error = None
+    while retries < 3:
+        try:
+            response = llm_client.generate(
+                user_prompt=user_prompt,
+                model=FACT_MODEL,
+            )
+            validate_res = json.loads(
+                response.replace("```json", "").replace("```", "")
+            )
+            for _v in validate_res:
+                _v["idx"] -= 1
+            assert len(validate_res) == len(facts)
+            return {"url": url, "validate_res": validate_res, "error": None}
+        except Exception as e:
+            error = str(e)
+            time.sleep(3)
+            retries += 1
+
+    return {"url": url, "validate_res": [], "error": error}
+
+
+def run_fact_evaluation(
+    task_name: str,
+    output_dir: str,
+    llm_client: GeminiClient,
+    max_workers: int = 10,
+):
+    """Run FACT evaluation."""
+    from tqdm import tqdm
+
+    fact_dir = os.path.join(output_dir, "fact", task_name)
+    scraped_path = os.path.join(fact_dir, "scraped.jsonl")
+    validated_path = os.path.join(fact_dir, "validated.jsonl")
+    result_path = os.path.join(fact_dir, "fact_result.txt")
+
+    if not os.path.exists(scraped_path):
+        logger.error(f"Scraped data not found: {scraped_path}")
+        return None
+
+    raw_data = load_jsonl(scraped_path)
+
+    # Load query data for language info
+    query_data = load_jsonl(get_query_file())
+    id_to_lang_map = {
+        item["id"]: item.get("language")
+        for item in query_data
+        if "id" in item and "language" in item
+    }
+
+    if not id_to_lang_map:
+        raise ValueError("No valid language information found in query data")
+
+    # Check existing results
+    if os.path.exists(validated_path):
+        processed = [d["id"] for d in load_jsonl(validated_path)]
+        data_to_process = [d for d in raw_data if d["id"] not in processed]
+    else:
+        data_to_process = raw_data
+
+    logger.info(f"FACT: Processing {len(data_to_process)} instances...")
+
+    for d in tqdm(data_to_process, desc="FACT Validation"):
+        citations = [(k, v) for k, v in d["citations_deduped"].items()]
+        article_id = d.get("id")
+        if not article_id:
+            continue
+
+        for citation in citations:
+            citation[1]["article_id"] = article_id
+
+        results = []
+        for citation in citations:
+            results.append(
+                validate_single_citation(citation, id_to_lang_map, llm_client)
+            )
+
+        for res in results:
+            d["citations_deduped"][res["url"]]["validate_res"] = res["validate_res"]
+            d["citations_deduped"][res["url"]]["validate_error"] = res["error"]
+
+        with open(validated_path, "a+", encoding="utf-8") as f:
+            f.write(json.dumps(d, ensure_ascii=False) + "\n")
+
+    # Compute statistics
+    total_citations = 0
+    total_valid_citations = 0
+    total_num = 0
+
+    all_validated = load_jsonl(validated_path)
+    for d in all_validated:
+        if not d.get("citations"):
+            continue
+        for c in d["citations_deduped"].values():
+            if c.get("validate_error") is not None:
+                continue
+            for _c in c.get("validate_res", []):
+                if _c["result"] != "unknown":
+                    total_citations += 1
+                    if _c["result"] == "supported":
+                        total_valid_citations += 1
+        total_num += 1
+
+    if total_num > 0 and total_citations > 0:
+        metrics = {
+            "avg_citations_per_article": total_citations / total_num,
+            "avg_valid_citations_per_article": total_valid_citations / total_num,
+            "valid_rate": total_valid_citations / total_citations,
+        }
+
+        with open(result_path, "w") as f:
+            for key, val in metrics.items():
+                f.write(f"{key}: {val:.4f}\n")
+
+        logger.info("\n=== FACT Evaluation Results ===")
+        for key, val in metrics.items():
+            logger.info(f"  {key}: {val:.4f}")
+        logger.info("================================")
+
+        return metrics
+    else:
+        logger.warning("No valid citations found for FACT evaluation")
+        return None
+
+
+# ============================================================================
+# Main entry point
+# ============================================================================
+def main():
+    parser = argparse.ArgumentParser(
+        description="Self-contained Deep Research Bench (DRB) Evaluation",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Full pipeline (format + RACE + FACT):
+  python run_eval.py --input_file eval_output/drb.jsonl --task_name my_model
+
+  # RACE only:
+  python run_eval.py --input_file eval_output/drb.jsonl --task_name my_model --skip_fact
+
+  # FACT only:
+  python run_eval.py --input_file eval_output/drb.jsonl --task_name my_model --skip_race
+
+  # With limit for testing:
+  python run_eval.py --input_file eval_output/drb.jsonl --task_name my_model --limit 2
+""",
+    )
+
+    parser.add_argument(
+        "--input_file",
+        type=str,
+        required=True,
+        help="Path to the DR Tulu output JSONL file",
+    )
+    parser.add_argument(
+        "--task_name",
+        type=str,
+        required=True,
+        help="Identifier for this evaluation run",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default=None,
+        help="Directory for evaluation output (default: same dir as input file)",
+    )
+    parser.add_argument(
+        "--max_workers",
+        type=int,
+        default=10,
+        help="Maximum number of concurrent workers (default: 10)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Limit number of examples to process (for testing)",
+    )
+    parser.add_argument(
+        "--only_zh",
+        action="store_true",
+        help="Only process Chinese data",
+    )
+    parser.add_argument(
+        "--only_en",
+        action="store_true",
+        help="Only process English data",
+    )
+    parser.add_argument(
+        "--skip_race",
+        action="store_true",
+        help="Skip RACE evaluation",
+    )
+    parser.add_argument(
+        "--skip_fact",
+        action="store_true",
+        help="Skip FACT evaluation",
+    )
+    parser.add_argument(
+        "--skip_cleaning",
+        action="store_true",
+        help="Skip article cleaning step in RACE evaluation",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force re-evaluation even if results exist",
+    )
+
+    args = parser.parse_args()
+
+    # Validate input
+    if not os.path.exists(args.input_file):
+        logger.error(f"Input file not found: {args.input_file}")
+        return
+
+    # Set output directory
+    if args.output_dir is None:
+        args.output_dir = os.path.join(
+            os.path.dirname(args.input_file), f"drb_eval_{args.task_name}"
+        )
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    logger.info(f"=== DRB Evaluation ===")
+    logger.info(f"Input: {args.input_file}")
+    logger.info(f"Task: {args.task_name}")
+    logger.info(f"Output: {args.output_dir}")
+
+    # Check API key
+    if not os.environ.get("GEMINI_API_KEY"):
+        logger.error("GEMINI_API_KEY environment variable not set")
+        return
+
+    # Initialize Gemini client
+    llm_client = GeminiClient(model=RACE_MODEL)
+
+    # Step 1: Format conversion
+    logger.info("\n--- Step 1: Format Conversion ---")
+    raw_data_path, scraped_data_path = run_format_conversion(
+        args.input_file, args.task_name, args.output_dir
+    )
+    logger.info(f"Raw data: {raw_data_path}")
+    logger.info(f"Scraped data: {scraped_data_path}")
+
+    # Step 2: RACE evaluation
+    if not args.skip_race:
+        logger.info("\n--- Step 2: RACE Evaluation ---")
+        race_metrics = run_race_evaluation(
+            task_name=args.task_name,
+            output_dir=args.output_dir,
+            llm_client=llm_client,
+            max_workers=args.max_workers,
+            limit=args.limit,
+            only_zh=args.only_zh,
+            only_en=args.only_en,
+            force=args.force,
+            skip_cleaning=args.skip_cleaning,
+        )
+    else:
+        logger.info("\n--- Step 2: RACE Evaluation (SKIPPED) ---")
+
+    # Step 3: FACT evaluation
+    if not args.skip_fact:
+        logger.info("\n--- Step 3: FACT Evaluation ---")
+        fact_metrics = run_fact_evaluation(
+            task_name=args.task_name,
+            output_dir=args.output_dir,
+            llm_client=llm_client,
+            max_workers=args.max_workers,
+        )
+    else:
+        logger.info("\n--- Step 3: FACT Evaluation (SKIPPED) ---")
+
+    logger.info("\n=== DRB Evaluation Complete ===")
+    logger.info(f"Results saved to: {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/agent/evaluation/deep_research_bench_eval/run_eval.py
+++ b/agent/evaluation/deep_research_bench_eval/run_eval.py
@@ -61,44 +61,62 @@ FACT_MODEL = "gemini-2.5-flash"
 RACE_MODEL = "gemini-2.5-pro"
 
 
-def _get_data_file(hf_filename: str, local_fallback: Path) -> str:
-    """Get a data file path: try local first, then download from HuggingFace."""
-    if local_fallback.exists():
-        return str(local_fallback)
+def _ensure_data_files() -> tuple:
+    """
+    Ensure DRB evaluation data files are available locally.
+    Downloads from HuggingFace if not found in local data/ directory.
+
+    Returns:
+        (criteria_file, reference_file, query_file) paths
+    """
+    criteria_file = DATA_DIR / "criteria_data" / "criteria.jsonl"
+    reference_file = DATA_DIR / "test_data" / "cleaned_data" / "reference.jsonl"
+    query_file = DATA_DIR / "prompt_data" / "query.jsonl"
+
+    # Check if all files exist locally
+    if criteria_file.exists() and reference_file.exists() and query_file.exists():
+        return criteria_file, reference_file, query_file
+
+    # Download from HuggingFace
+    logger.info(f"Downloading DRB evaluation data from {HF_EVAL_DATA_REPO}...")
     try:
         from huggingface_hub import hf_hub_download
-        path = hf_hub_download(
-            repo_id=HF_EVAL_DATA_REPO,
-            filename=hf_filename,
-            repo_type="dataset",
-        )
-        logger.info(f"Downloaded {hf_filename} from {HF_EVAL_DATA_REPO}")
-        return path
-    except Exception as e:
-        raise FileNotFoundError(
-            f"Data file not found locally at {local_fallback} and failed to download "
-            f"from {HF_EVAL_DATA_REPO}/{hf_filename}: {e}\n"
-            f"Install huggingface_hub: pip install huggingface_hub"
+    except ImportError:
+        raise ImportError(
+            "huggingface_hub required to download eval data. "
+            "Install with: pip install huggingface_hub"
         )
 
+    cache_dir = DATA_DIR / "hf_cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
 
-def get_criteria_file() -> str:
-    return _get_data_file(
-        "deep_research_bench/criteria.jsonl",
-        DATA_DIR / "criteria_data" / "criteria.jsonl",
-    )
+    hf_files = {
+        "deep_research_bench/query.jsonl": query_file,
+        "deep_research_bench/criteria.jsonl": criteria_file,
+        "deep_research_bench/reference.jsonl": reference_file,
+    }
+    for hf_path, local_path in hf_files.items():
+        if not local_path.exists():
+            logger.info(f"  Downloading {hf_path}...")
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            downloaded = hf_hub_download(
+                repo_id=HF_EVAL_DATA_REPO,
+                filename=hf_path,
+                repo_type="dataset",
+                cache_dir=str(cache_dir),
+            )
+            # Symlink or copy to expected path
+            import shutil
+            shutil.copy2(downloaded, local_path)
 
-def get_reference_file() -> str:
-    return _get_data_file(
-        "deep_research_bench/reference.jsonl",
-        DATA_DIR / "test_data" / "cleaned_data" / "reference.jsonl",
-    )
+    logger.info("DRB evaluation data ready.")
+    return criteria_file, reference_file, query_file
 
-def get_query_file() -> str:
-    return _get_data_file(
-        "deep_research_bench/query.jsonl",
-        DATA_DIR / "prompt_data" / "query.jsonl",
-    )
+
+# Resolved at runtime
+CRITERIA_FILE = None
+REFERENCE_FILE = None
+QUERY_FILE = None
 
 
 # ============================================================================
@@ -1245,13 +1263,13 @@ def run_race_evaluation(
             )
 
         # Load all data
-        all_tasks = load_jsonl(get_query_file())
+        all_tasks = load_jsonl(str(QUERY_FILE))
         all_tasks = [t for t in all_tasks if t.get("language") == language]
         if limit is not None and limit > 0:
             all_tasks = all_tasks[:limit]
 
         task_prompts = {t["prompt"] for t in all_tasks if "prompt" in t}
-        all_criteria = load_jsonl(get_criteria_file())
+        all_criteria = load_jsonl(str(CRITERIA_FILE))
         criteria_list = [c for c in all_criteria if c.get("prompt") in task_prompts]
 
         target_file = os.path.join(cleaned_data_dir, f"{task_name}.jsonl")
@@ -1265,7 +1283,7 @@ def run_race_evaluation(
             logger.warning(f"No target articles found for {language}")
             continue
 
-        all_reference = load_jsonl(get_reference_file())
+        all_reference = load_jsonl(str(REFERENCE_FILE))
         reference_list = [a for a in all_reference if a.get("prompt") in task_prompts]
 
         # Build maps
@@ -1420,7 +1438,7 @@ def run_fact_evaluation(
     raw_data = load_jsonl(scraped_path)
 
     # Load query data for language info
-    query_data = load_jsonl(get_query_file())
+    query_data = load_jsonl(str(QUERY_FILE))
     id_to_lang_map = {
         item["id"]: item.get("language")
         for item in query_data
@@ -1599,6 +1617,10 @@ Examples:
             os.path.dirname(args.input_file), f"drb_eval_{args.task_name}"
         )
     os.makedirs(args.output_dir, exist_ok=True)
+
+    # Initialize data files (download from HF if needed)
+    global CRITERIA_FILE, REFERENCE_FILE, QUERY_FILE
+    CRITERIA_FILE, REFERENCE_FILE, QUERY_FILE = _ensure_data_files()
 
     logger.info(f"=== DRB Evaluation ===")
     logger.info(f"Input: {args.input_file}")

--- a/agent/evaluation/sqa_eval/README.md
+++ b/agent/evaluation/sqa_eval/README.md
@@ -1,0 +1,114 @@
+## Introduction
+
+We evaluate on SQA-CS-V2 (Scientific Question Answering with Structured Citations) using the [astabench](https://pypi.org/project/astabench/) evaluation framework.
+
+SQA-CS-V2 measures both answer quality and citation quality:
+- **ingredient_recall**: Coverage of key facts from the rubric
+- **answer_precision**: Avoidance of incorrect statements
+- **citation_recall / citation_precision**: Quality of supporting citations
+- **global_avg**: Overall weighted score
+
+---
+
+## Self-Contained Evaluation (Recommended)
+
+The self-contained script `run_eval.py` handles format conversion and evaluation. **No external repo needed.**
+
+### Prerequisites
+
+```bash
+pip install uv  # Recommended: auto-manages Python 3.11 + astabench
+export GOOGLE_API_KEY="your_google_api_key_here"
+export HF_TOKEN="your_hf_token_here"   # Needs access to allenai/asta-bench (gated dataset)
+```
+
+> **Note**: `astabench` requires Python ≥3.11. The script auto-manages this via `uv run` if your current Python is older. Alternatively, install directly: `pip install astabench==0.3.1 inspect_ai datasets` (requires Python ≥3.11).
+
+### Quick Start
+
+```bash
+# Full pipeline: convert + evaluate
+python evaluation/sqa_eval/run_eval.py run \
+    --input_file eval_output/auto_search_sft/sqa_cs_v2.jsonl
+
+# Step-by-step:
+# 1. Convert DR Tulu output to ASTA format
+python evaluation/sqa_eval/run_eval.py convert \
+    --input_file eval_output/auto_search_sft/sqa_cs_v2.jsonl
+
+# 2. Run evaluation
+python evaluation/sqa_eval/run_eval.py eval \
+    --input_file eval_output/auto_search_sft/sqa_cs_v2_asta_format.jsonl
+
+# With custom scorer model and connections:
+python evaluation/sqa_eval/run_eval.py run \
+    --input_file eval_output/auto_search_sft/sqa_cs_v2.jsonl \
+    --scorer_model "google/gemini-2.5-flash" \
+    --max_connections 16
+```
+
+### Via the unified evaluate.py
+
+```bash
+python scripts/evaluate.py sqa_cs_v2 eval_output/auto_search_sft/sqa_cs_v2.jsonl
+```
+
+### SQA Response Format
+
+SQA-CS-V2 requires responses in a specific JSON format with structured sections and citations:
+
+```json
+{
+  "sections": [
+    {
+      "text": "text of section 1",
+      "citations": [
+        {
+          "id": "[cite_id]",
+          "title": "paper title",
+          "snippets": ["evidence 1", "evidence 2"]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Example Test Data
+
+Example DR-Tulu outputs and their ASTA-format conversions are available at [`rl-research/dr-tulu-eval-data`](https://huggingface.co/datasets/rl-research/dr-tulu-eval-data) under `sqa/`.
+
+---
+
+## Legacy Method (External Repo)
+
+If you prefer using the original [agent-baselines](https://github.com/allenai/agent-baselines) repository:
+
+1. **Convert DR Tulu outputs to SQA format**:
+   ```bash
+   python evaluation/sqa_eval/convert_to_asta_format.py --folder <folder_name> --file <file_name>
+   ```
+
+2. **Clone the evaluation repository**:
+   ```bash
+   git clone https://github.com/allenai/agent-baselines
+   cd agent-baselines
+   ```
+
+3. **Run evaluation**:
+   ```bash
+   uv run --extra sqa inspect eval astabench/sqa --display plain \
+     --solver agent_baselines/solvers/sqa/debug/cached_solver.py \
+     -S path=<outputfile_from_step1> \
+     -T split=test \
+     -T with_search_tools=False \
+     -T simplified_eval=true \
+     -T assess_jointly=true \
+     --max-connections 16 \
+     -T sentence_wise_cit_eval=false \
+     -T all_at_once=true \
+     -T scorer_model="google/gemini-2.5-flash"
+   ```
+
+**Note**: Export `GOOGLE_API_KEY` and `HF_TOKEN` before running.
+

--- a/agent/evaluation/sqa_eval/convert_to_asta_format.py
+++ b/agent/evaluation/sqa_eval/convert_to_asta_format.py
@@ -151,29 +151,35 @@ def parse_answer(sample: str) -> List[Dict[str, Any]]:
 
     return sections
 
-parser = argparse.ArgumentParser(description="Convert files to ASTA format")
-parser.add_argument('--folder', type=str, required=True, help='Path to the folder where eval file is stored')
-parser.add_argument('--file', type=str, required=True, help='Name of the eval file')
-args = parser.parse_args()
-folder = args.folder
-file = args.file
+def main():
+    parser = argparse.ArgumentParser(description="Convert DR Tulu output files to ASTA format for SQA evaluation")
+    parser.add_argument('--folder', type=str, required=True, help='Path to the folder where eval file is stored')
+    parser.add_argument('--file', type=str, required=True, help='Name of the eval file')
+    args = parser.parse_args()
+    folder = args.folder
+    file = args.file
 
-print(f"Processing file: {file}")
-# read data
-file_path = os.path.join(folder, file)
-data = []
+    print(f"Processing file: {file}")
+    # read data
+    file_path = os.path.join(folder, file)
+    data = []
 
-with open(file_path, 'r') as f:
-    for line in f:
-        data.append(json.loads(line))
+    with open(file_path, 'r') as f:
+        for line in f:
+            data.append(json.loads(line))
 
-formatted = []
-for sample in data:
-    parsed = parse_answer(sample)
-    formatted.append({"question": sample['problem'], "response": {"sections": parsed}})
+    formatted = []
+    for sample in data:
+        parsed = parse_answer(sample)
+        formatted.append({"question": sample['problem'], "response": {"sections": parsed}})
+
+    # write formatted data to a json file
+    out_file = file_path.replace(".jsonl", "_asta_format.jsonl")
+    with open(out_file, "w") as f:
+        json.dump(formatted, f, indent=4)
+
+    print(f"Converted {len(formatted)} samples -> {out_file}")
 
 
-# write formatted data to a json file
-out_file = file_path.replace(".jsonl", "_asta_format.jsonl")
-with open(out_file, "w") as f:
-    json.dump(formatted, f, indent=4)
+if __name__ == "__main__":
+    main()

--- a/agent/evaluation/sqa_eval/run_eval.py
+++ b/agent/evaluation/sqa_eval/run_eval.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+"""
+Self-contained SQA-CS-V2 evaluation script.
+
+Runs the SQA evaluation pipeline without requiring the external agent-baselines
+repository. This script wraps the `astabench` and `inspect_ai` packages.
+
+Usage:
+    # Step 1: Convert DR Tulu output to ASTA format
+    python run_eval.py convert --input_file <path/to/sqa_output.jsonl>
+
+    # Step 2: Run SQA evaluation on the converted file
+    python run_eval.py eval --input_file <path/to/sqa_output_asta_format.jsonl>
+
+    # Or run both steps in one command
+    python run_eval.py run --input_file <path/to/sqa_output.jsonl>
+
+    # With options
+    python run_eval.py run --input_file <path/to/sqa_output.jsonl> \
+        --scorer_model "google/gemini-2.5-flash" \
+        --max_connections 16 \
+        --split test
+
+Environment Variables Required:
+    GOOGLE_API_KEY: Google API key (for Gemini-based scoring)
+    HF_TOKEN: Hugging Face token (can be dummy if data is local)
+
+Dependencies:
+    pip install astabench==0.3.1 inspect_ai datasets
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Import DR Tulu format conversion from Varsha's script (single source of truth)
+sys.path.insert(0, str(Path(__file__).parent))
+from convert_to_asta_format import parse_answer
+
+
+def convert_to_asta_format(input_file: str, output_file: str = None) -> str:
+    """
+    Convert DR Tulu output to ASTA format for SQA evaluation.
+
+    Uses the DR Tulu citation format: <cite id="xxx">text</cite> in final_response
+    with <snippet id="xxx">content</snippet> in tool call traces.
+
+    Args:
+        input_file: Path to the DR Tulu output JSONL file
+        output_file: Path for the output file (default: input_file with _asta_format suffix)
+
+    Returns:
+        Path to the output file
+    """
+    if output_file is None:
+        output_file = input_file.replace(".jsonl", "_asta_format.jsonl")
+
+    print(f"Converting (DR Tulu format): {input_file}")
+
+    data = []
+    with open(input_file, "r") as f:
+        for line in f:
+            data.append(json.loads(line))
+
+    formatted = []
+    for i, sample in enumerate(data):
+        try:
+            parsed = parse_answer(sample)
+            formatted.append(
+                {
+                    "question": sample["problem"],
+                    "response": {"sections": parsed},
+                }
+            )
+        except Exception as e:
+            print(f"Warning: Failed to convert sample {i}: {e}")
+
+    with open(output_file, "w") as f:
+        json.dump(formatted, f, indent=4)
+
+    print(f"Converted {len(formatted)}/{len(data)} samples -> {output_file}")
+    return output_file
+
+
+# ============================================================================
+# SQA Evaluation (wrapping astabench/inspect)
+# ============================================================================
+def check_dependencies():
+    """Check if required packages are installed."""
+    missing = []
+    try:
+        import astabench
+    except ImportError:
+        missing.append("astabench==0.3.1")
+
+    try:
+        import inspect_ai
+    except ImportError:
+        missing.append("inspect_ai")
+
+    try:
+        import datasets
+    except ImportError:
+        missing.append("datasets")
+
+    if missing:
+        print(f"Missing dependencies: {', '.join(missing)}")
+        print(f"Install with: pip install {' '.join(missing)}")
+        return False
+    return True
+
+
+def create_cached_solver_script(data_path: str, split: str = "test") -> str:
+    """
+    Create a temporary solver script that loads cached results.
+
+    This replicates the behavior of agent_baselines/solvers/sqa/debug/cached_solver.py
+    without needing the agent-baselines repo.
+    """
+    solver_code = f'''
+import json
+from pathlib import Path
+
+from astabench.types.sqa import SQAResponse, SQAResponseWithUsage
+from astabench.util.model import record_model_usage_with_inspect
+from inspect_ai.model import ChatMessageAssistant, ModelUsage
+from inspect_ai.solver import Generate, Solver, TaskState, solver
+from datasets.utils.logging import set_verbosity_error
+
+set_verbosity_error()
+import os
+from datasets import load_dataset
+
+_dataset = None
+
+def _load_dataset(path: str, split: str):
+    global _dataset
+    if _dataset is None:
+        if os.path.exists(path):
+            print(f"Loading data from local file: {{path}}")
+            _dataset = load_dataset("json", data_files={{split: path}})[split]
+        else:
+            raise FileNotFoundError(f"Data file not found: {{path}}")
+
+def _read_q_result(question: str):
+    results = _dataset.filter(lambda x: x["question"] == question)
+    if len(results) == 0:
+        return None
+    return results[0]["response"]
+
+def _query_cache(question: str):
+    response_dict = _read_q_result(question)
+    if response_dict is None:
+        raise ValueError(f"No results found for question: {{question}}")
+    response = (
+        SQAResponseWithUsage(**response_dict)
+        if "tokens" in response_dict
+        else SQAResponse(**response_dict)
+    )
+    return response
+
+@solver
+def cache_solver(
+    path: str = "{data_path}",
+    split: str = "{split}",
+    model: str = "openai/gpt-4.1",
+) -> Solver:
+    _load_dataset(path, split)
+
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        question = state.metadata["initial_prompt"]
+        response = _query_cache(question)
+        content = json.dumps(
+            {{"response": response.model_dump(mode="json", exclude={{"tokens"}})}},
+            indent=2,
+        )
+        if hasattr(response, "tokens"):
+            usage_dict = {{f"{{k}}_tokens": v for k, v in response.tokens.items()}}
+            record_model_usage_with_inspect(
+                model_name=model,
+                usage=ModelUsage(**usage_dict),
+            )
+        state.messages.append(ChatMessageAssistant(content=content))
+        state.output.completion = content
+        return state
+
+    return solve
+'''
+    return solver_code
+
+
+def _build_inspect_cmd(
+    solver_path: str,
+    input_file: str,
+    split: str,
+    scorer_model: str,
+    max_connections: int,
+    simplified_eval: bool,
+    assess_jointly: bool,
+    sentence_wise_cit_eval: bool,
+    all_at_once: bool,
+    with_search_tools: bool,
+    output_dir: str = None,
+) -> List[str]:
+    """Build the inspect eval command arguments (without the python/uv prefix)."""
+    args = [
+        "eval", "astabench/sqa",
+        "--display", "plain",
+        "--solver", solver_path,
+        "-S", f"path={os.path.abspath(input_file)}",
+        "-T", f"split={split}",
+        "-T", f"with_search_tools={with_search_tools}",
+        "-T", f"simplified_eval={str(simplified_eval).lower()}",
+        "-T", f"assess_jointly={str(assess_jointly).lower()}",
+        "--max-connections", str(max_connections),
+        "-T", f"sentence_wise_cit_eval={str(sentence_wise_cit_eval).lower()}",
+        "-T", f"all_at_once={str(all_at_once).lower()}",
+        "-T", f"scorer_model={scorer_model}",
+    ]
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+        args.extend(["--log-dir", output_dir])
+    return args
+
+
+def _check_uv_available() -> bool:
+    """Check if uv is available."""
+    try:
+        result = subprocess.run(["uv", "--version"], capture_output=True, text=True)
+        return result.returncode == 0
+    except FileNotFoundError:
+        return False
+
+
+def run_sqa_evaluation(
+    input_file: str,
+    split: str = "test",
+    scorer_model: str = "google/gemini-2.5-flash",
+    max_connections: int = 16,
+    simplified_eval: bool = True,
+    assess_jointly: bool = True,
+    sentence_wise_cit_eval: bool = False,
+    all_at_once: bool = True,
+    with_search_tools: bool = False,
+    output_dir: str = None,
+):
+    """
+    Run SQA evaluation using astabench + inspect_ai.
+
+    Automatically handles the Python 3.11+ requirement:
+    - If current Python >= 3.11 and packages are installed: runs directly
+    - Otherwise: uses `uv run` with a temporary project to manage dependencies
+
+    Args:
+        input_file: Path to the ASTA-formatted JSONL file
+        split: Dataset split to evaluate on (test/dev)
+        scorer_model: Model to use for scoring
+        max_connections: Maximum concurrent connections
+        simplified_eval: Use simplified evaluation
+        assess_jointly: Assess jointly
+        sentence_wise_cit_eval: Sentence-wise citation evaluation
+        all_at_once: Process all at once
+        with_search_tools: Whether to use search tools
+        output_dir: Directory for evaluation output
+    """
+    # Check environment variables
+    if not os.environ.get("GOOGLE_API_KEY"):
+        print("WARNING: GOOGLE_API_KEY not set. Required for Gemini-based scoring.")
+        print("Set it with: export GOOGLE_API_KEY='your_key_here'")
+
+    # Create temporary solver script
+    solver_code = create_cached_solver_script(
+        data_path=os.path.abspath(input_file), split=split
+    )
+
+    # Write to temporary directory
+    solver_dir = tempfile.mkdtemp(prefix="sqa_eval_")
+    solver_path = os.path.join(solver_dir, "cached_solver.py")
+    with open(solver_path, "w") as f:
+        f.write(solver_code)
+
+    # Build inspect eval arguments
+    inspect_args = _build_inspect_cmd(
+        solver_path=solver_path,
+        input_file=input_file,
+        split=split,
+        scorer_model=scorer_model,
+        max_connections=max_connections,
+        simplified_eval=simplified_eval,
+        assess_jointly=assess_jointly,
+        sentence_wise_cit_eval=sentence_wise_cit_eval,
+        all_at_once=all_at_once,
+        with_search_tools=with_search_tools,
+        output_dir=output_dir,
+    )
+
+    # Determine execution method
+    use_uv = False
+    py_version = sys.version_info
+
+    if py_version >= (3, 11) and check_dependencies():
+        # Direct execution: Python >= 3.11 and deps installed
+        cmd = [sys.executable, "-m", "inspect_ai._cli.main"] + inspect_args
+    elif _check_uv_available():
+        # Use uv run: manages Python version + deps automatically
+        use_uv = True
+        # Create a temporary pyproject.toml for uv
+        pyproject_content = """
+[project]
+name = "sqa-eval-runner"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "astabench==0.3.1",
+    "inspect_ai",
+    "datasets",
+]
+
+[tool.uv]
+override-dependencies = [
+    "openai==1.78.0",
+]
+"""
+        pyproject_path = os.path.join(solver_dir, "pyproject.toml")
+        with open(pyproject_path, "w") as f:
+            f.write(pyproject_content)
+
+        cmd = [
+            "uv", "run", "--python", "3.11",
+            "inspect",
+        ] + inspect_args
+    else:
+        print("ERROR: Cannot run SQA evaluation:")
+        print(f"  - Current Python: {py_version.major}.{py_version.minor} (need >= 3.11)")
+        print(f"  - astabench requires Python >= 3.11")
+        print()
+        print("Options:")
+        print("  1. Install uv: pip install uv")
+        print("  2. Use Python >= 3.11 with: pip install astabench==0.3.1 inspect_ai datasets")
+        print("  3. Create a conda env: conda create -n sqa_eval python=3.11 && conda activate sqa_eval && pip install astabench==0.3.1 inspect_ai datasets")
+        # Cleanup
+        try:
+            import shutil
+            shutil.rmtree(solver_dir)
+        except Exception:
+            pass
+        sys.exit(1)
+
+    print(f"\n=== Running SQA Evaluation ===")
+    print(f"Input file: {input_file}")
+    print(f"Split: {split}")
+    print(f"Scorer model: {scorer_model}")
+    print(f"Max connections: {max_connections}")
+    print(f"Method: {'uv run (auto-managed Python 3.11+)' if use_uv else 'direct'}")
+    print(f"Command: {' '.join(cmd)}")
+    print()
+
+    # Pass through environment variables, set dummy keys if needed
+    env = os.environ.copy()
+    # astabench entrypoint loading requires OPENAI_API_KEY even when not using OpenAI
+    if not env.get("OPENAI_API_KEY"):
+        env["OPENAI_API_KEY"] = "dummy-not-used"
+    # HF_TOKEN is needed for downloading gated allenai/asta-bench dataset
+    if not env.get("HF_TOKEN"):
+        # Try to get token from huggingface-cli login cache
+        try:
+            from huggingface_hub import HfFolder
+            cached_token = HfFolder.get_token()
+            if cached_token:
+                env["HF_TOKEN"] = cached_token
+                print(f"Using cached HF token from huggingface-cli login")
+        except Exception:
+            pass
+    if not env.get("HF_TOKEN"):
+        print("WARNING: HF_TOKEN not set. Needed for gated allenai/asta-bench dataset.")
+        print("  Run: huggingface-cli login")
+        print("  Or set: export HF_TOKEN='your_token'")
+        print("  And request access at: https://huggingface.co/datasets/allenai/asta-bench")
+
+    # Run the evaluation
+    result = subprocess.run(cmd, cwd=solver_dir, env=env)
+
+    # Cleanup
+    try:
+        import shutil
+        shutil.rmtree(solver_dir)
+    except Exception:
+        pass
+
+    if result.returncode != 0:
+        print(f"\nEvaluation failed with return code {result.returncode}")
+        sys.exit(result.returncode)
+    else:
+        print(f"\n=== SQA Evaluation Complete ===")
+        if output_dir:
+            print(f"Logs saved to: {output_dir}")
+
+
+# ============================================================================
+# Main entry point
+# ============================================================================
+def main():
+    parser = argparse.ArgumentParser(
+        description="Self-contained SQA-CS-V2 Evaluation",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Convert DR Tulu output to ASTA format:
+  python run_eval.py convert --input_file eval_output/sqa.jsonl
+
+  # Run evaluation on converted file:
+  python run_eval.py eval --input_file eval_output/sqa_asta_format.jsonl
+
+  # Full pipeline (convert + evaluate):
+  python run_eval.py run --input_file eval_output/sqa.jsonl
+
+  # With custom scorer model:
+  python run_eval.py run --input_file eval_output/sqa.jsonl \\
+      --scorer_model "google/gemini-2.5-flash"
+""",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", help="Command to run")
+
+    # Convert command
+    convert_parser = subparsers.add_parser(
+        "convert", help="Convert DR Tulu output to ASTA format"
+    )
+    convert_parser.add_argument(
+        "--input_file",
+        type=str,
+        required=True,
+        help="Path to the DR Tulu output JSONL file",
+    )
+    convert_parser.add_argument(
+        "--output_file",
+        type=str,
+        default=None,
+        help="Path for the output file (default: auto-generated)",
+    )
+
+    # Eval command
+    eval_parser = subparsers.add_parser(
+        "eval", help="Run SQA evaluation on ASTA-formatted file"
+    )
+    eval_parser.add_argument(
+        "--input_file",
+        type=str,
+        required=True,
+        help="Path to the ASTA-formatted JSONL file",
+    )
+    eval_parser.add_argument(
+        "--split",
+        type=str,
+        default="test",
+        help="Dataset split (default: test)",
+    )
+    eval_parser.add_argument(
+        "--scorer_model",
+        type=str,
+        default="google/gemini-2.5-flash",
+        help="Scorer model (default: google/gemini-2.5-flash)",
+    )
+    eval_parser.add_argument(
+        "--max_connections",
+        type=int,
+        default=16,
+        help="Maximum concurrent connections (default: 16)",
+    )
+    eval_parser.add_argument(
+        "--output_dir",
+        type=str,
+        default=None,
+        help="Directory for evaluation output logs",
+    )
+
+    # Run command (convert + eval)
+    run_parser = subparsers.add_parser(
+        "run", help="Full pipeline: convert + evaluate"
+    )
+    run_parser.add_argument(
+        "--input_file",
+        type=str,
+        required=True,
+        help="Path to the DR Tulu output JSONL file",
+    )
+    run_parser.add_argument(
+        "--split",
+        type=str,
+        default="test",
+        help="Dataset split (default: test)",
+    )
+    run_parser.add_argument(
+        "--scorer_model",
+        type=str,
+        default="google/gemini-2.5-flash",
+        help="Scorer model (default: google/gemini-2.5-flash)",
+    )
+    run_parser.add_argument(
+        "--max_connections",
+        type=int,
+        default=16,
+        help="Maximum concurrent connections (default: 16)",
+    )
+    run_parser.add_argument(
+        "--output_dir",
+        type=str,
+        default=None,
+        help="Directory for evaluation output logs",
+    )
+
+    args = parser.parse_args()
+
+    if args.command is None:
+        parser.print_help()
+        return
+
+    if args.command == "convert":
+        convert_to_asta_format(args.input_file, args.output_file)
+
+    elif args.command == "eval":
+        run_sqa_evaluation(
+            input_file=args.input_file,
+            split=args.split,
+            scorer_model=args.scorer_model,
+            max_connections=args.max_connections,
+            output_dir=args.output_dir,
+        )
+
+    elif args.command == "run":
+        # Step 1: Convert
+        print("=== Step 1: Format Conversion ===")
+        asta_file = convert_to_asta_format(args.input_file)
+
+        # Step 2: Evaluate
+        print("\n=== Step 2: SQA Evaluation ===")
+        run_sqa_evaluation(
+            input_file=asta_file,
+            split=args.split,
+            scorer_model=args.scorer_model,
+            max_connections=args.max_connections,
+            output_dir=args.output_dir,
+        )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/agent/scripts/evaluate.py
+++ b/agent/scripts/evaluate.py
@@ -308,7 +308,34 @@ def main():
         print(f"Error: File must be a JSONL file: {args.file_path}")
         sys.exit(1)
 
-    if args.task == "researchqa":
+    if args.task == "deep_research_bench":
+        # Self-contained DRB evaluation (RACE + FACT)
+        import subprocess
+        drb_script = str(Path(__file__).parent.parent / "evaluation" / "deep_research_bench_eval" / "run_eval.py")
+        task_name = Path(args.file_path).stem
+        cmd = [
+            sys.executable, drb_script,
+            "--input_file", args.file_path,
+            "--task_name", task_name,
+        ]
+        if args.save_path:
+            cmd.extend(["--output_dir", args.save_path])
+        print(f"Running DRB evaluation: {' '.join(cmd)}")
+        subprocess.run(cmd)
+    elif args.task == "sqa_cs_v2":
+        # Self-contained SQA evaluation
+        import subprocess
+        sqa_script = str(Path(__file__).parent.parent / "evaluation" / "sqa_eval" / "run_eval.py")
+        cmd = [
+            sys.executable, sqa_script,
+            "run",
+            "--input_file", args.file_path,
+        ]
+        if args.save_path:
+            cmd.extend(["--output_dir", args.save_path])
+        print(f"Running SQA evaluation: {' '.join(cmd)}")
+        subprocess.run(cmd)
+    elif args.task == "researchqa":
         evaluate_researchqa(
             args.file_path,
             args.save_path,


### PR DESCRIPTION
## Summary

Add self-contained evaluation scripts for **Deep Research Bench (DRB)** and **SQA-CS-V2** so users no longer need to clone external repos ([deep_research_bench](https://github.com/Ayanami0730/deep_research_bench) or [agent-baselines](https://github.com/allenai/agent-baselines)) to run evaluations.

### What changed

**New files:**
- `evaluation/deep_research_bench_eval/run_eval.py` — Self-contained DRB evaluation (RACE + FACT)
- `evaluation/sqa_eval/run_eval.py` — Self-contained SQA-CS-V2 evaluation (wraps astabench via `uv`)

**Updated files:**
- `scripts/evaluate.py` — Added `deep_research_bench` and `sqa_cs_v2` as supported task types
- `evaluation/README.md` — Documented self-contained usage for both benchmarks
- `evaluation/deep_research_bench_eval/README.md` — Updated with self-contained instructions
- `.gitignore` — Exclude eval data files (now hosted on HF)

**Data migration:**
- Evaluation data moved to [`rl-research/dr-tulu-eval-data`](https://huggingface.co/datasets/rl-research/dr-tulu-eval-data) on HuggingFace
- DRB data (query.jsonl, criteria.jsonl, reference.jsonl) auto-downloaded from HF on first run
- Removed `test.jsonl` and `test_asta_format.jsonl` from git tracking (~15MB freed)

**Bug fixes:**
- Fixed deprecated Gemini model names (`gemini-2.5-pro-preview-06-05` → `gemini-2.5-pro`, `gemini-2.5-flash-preview-09-2025` → `gemini-2.5-flash`)
- SQA eval: auto-manages Python 3.11+ requirement via `uv run` (astabench needs >=3.11)
- SQA eval: auto-detects cached HF token from `huggingface-cli login`
- SQA eval: sets dummy `OPENAI_API_KEY` to avoid astabench entrypoint crash when using Gemini scorer

---

## How to run experiments

### Prerequisites
```bash
# Install dr-agent
cd agent && pip install -e .

# DRB eval deps
pip install google-genai tqdm huggingface_hub

# SQA eval deps (handled automatically by uv, or manual):
pip install uv  # recommended: manages Python 3.11 + astabench automatically
# OR: pip install astabench==0.3.1 inspect_ai datasets  (requires Python >=3.11)

# API keys
export GEMINI_API_KEY="your_key"
export GOOGLE_API_KEY="$GEMINI_API_KEY"
# For SQA: need HF token with access to allenai/asta-bench (gated dataset)
huggingface-cli login
```

### Step 1: Serve model + MCP server
```bash
# Launch vLLM (2 GPUs)
CUDA_VISIBLE_DEVICES=0 vllm serve rl-research/DR-Tulu-8B --revision step_4000 --dtype auto --port 30001 --max-model-len 40960
CUDA_VISIBLE_DEVICES=1 vllm serve Qwen/Qwen3-8B --dtype auto --port 30002 --max-model-len 40960

# Launch MCP server
python -m dr_agent.mcp_backend.main --port 8000
```

### Step 2: Generate outputs
```bash
cd agent
mkdir -p eval_output/dr_tulu_8b_step4000

# SQA (~15 min, 100 samples)
python workflows/auto_search_sft.py generate-dataset sqav2 \
    --num-examples final_run --max-concurrent 20 --batch-size 20 --use-cache \
    --config workflows/auto_search_sft.yaml \
    --config-overrides "use_browse_agent=true,search_agent_max_tool_calls=10,browse_tool_name=jina" \
    --output eval_output/dr_tulu_8b_step4000/sqav2.jsonl

# DRB (~25 min, 100 samples)
python workflows/auto_search_sft.py generate-dataset deep_research_bench \
    --num-examples final_run --max-concurrent 20 --batch-size 20 --use-cache \
    --config workflows/auto_search_sft.yaml \
    --config-overrides "use_browse_agent=true,search_agent_max_tool_calls=10,browse_tool_name=jina" \
    --output eval_output/dr_tulu_8b_step4000/deep_research_bench.jsonl
```

### Step 3: Evaluate
```bash
# SQA evaluation (~30 min, uses Gemini Flash as scorer)
python evaluation/sqa_eval/run_eval.py run \
    --input_file eval_output/dr_tulu_8b_step4000/sqav2.jsonl \
    --max_connections 16

# DRB evaluation (~4-5 hours total: ~10 min cleaning, ~20 min RACE, ~4 hours FACT)
python evaluation/deep_research_bench_eval/run_eval.py \
    --input_file eval_output/dr_tulu_8b_step4000/deep_research_bench.jsonl \
    --task_name dr_tulu_8b_step4000

# Or via unified script:
python scripts/evaluate.py deep_research_bench eval_output/dr_tulu_8b_step4000/deep_research_bench.jsonl
python scripts/evaluate.py sqa_cs_v2 eval_output/dr_tulu_8b_step4000/sqav2.jsonl
```

---

## Experimental Results

Evaluated [`rl-research/DR-Tulu-8B`](https://huggingface.co/rl-research/DR-Tulu-8B/tree/step_4000) (step_4000 checkpoint) on both benchmarks. Generation used `auto_search_sft` workflow with browse agent + jina browsing.

### SQA-CS-V2 (100 samples, scorer: `gemini-2.5-flash`)

| Metric | Score |
|--------|-------|
| ingredient_recall | 0.9020 |
| answer_precision | 0.9860 |
| citation_recall | 0.4968 |
| citation_precision | 0.7191 |
| f1 | 0.5830 |
| **global_avg** | **0.7760** |

- Strong factual coverage (ingredient_recall 0.90, answer_precision 0.99)
- Citation quality has room for improvement (citation_recall 0.50)

### Deep Research Bench — RACE (100 samples, scorer: `gemini-2.5-pro`)

Normalized scores (0-1 scale, 0.5 = ties with Claude 3.7 Sonnet reference):

| Metric | Score |
|--------|-------|
| Comprehensiveness | 0.4476 |
| Insight | 0.4520 |
| Instruction Following | 0.4954 |
| Readability | 0.4088 |
| **Overall RACE** | **0.4574** |

- Nearly tied with Claude 3.7 Sonnet on instruction following (0.495)
- Competitive overall at 0.457 against a much larger frontier model
- DRB FACT evaluation (citation verification) is still running (~4 hours total)

### Models used
| Role | Model |
|------|-------|
| Report generation | `rl-research/DR-Tulu-8B` (step_4000) |
| Browse agent | `Qwen/Qwen3-8B` |
| SQA scorer | `google/gemini-2.5-flash` (aligned with astabench default) |
| DRB RACE scorer | `google/gemini-2.5-pro` (aligned with original DRB repo) |
| DRB FACT validator | `google/gemini-2.5-flash` (aligned with original DRB repo) |
