### PR TITLE
Added FrontierScience eval

### DIFF
--- a/agent/dr_agent/dataset_utils/load_dataset.py
+++ b/agent/dr_agent/dataset_utils/load_dataset.py
@@ -17,6 +17,8 @@ SUPPORTED_TASKS = {
     "genetic_diseases_qa": "rl-research/genetic_diseases_qa",
     "deep_scholar_bench": "xinranz3/deepscholar_bench_fixed",
     "deep_research_bench": "rl-research/deep_research_bench_eval",
+    "frontierscience_olympiad": "openai/frontierscience",
+    "frontierscience_research": "openai/frontierscience",
     "sqav2": "allenai/asta-bench",
     "researchqa": "realliyifei/ResearchQA",
     "2wiki": "akariasai/2wiki_rand1k",
@@ -73,6 +75,8 @@ def get_ablation_sample_size(benchmark: str, subset_name: str = None) -> int:
         "researchqa": 100,
         "deep_scholar_bench": 63,
         "deep_research_bench": 100,
+        "frontierscience_olympiad": 50,
+        "frontierscience_research": 20,
         "sqav2": 100,
         "genetic_diseases_qa": 47,
         "2wiki": 100,
@@ -134,6 +138,13 @@ def load_dataset(config: DatasetConfig) -> List[Dict]:
         return load_deep_scholar_bench_data(num_examples)
     elif config["name"] == "deep_research_bench":
         return load_deep_research_bench_data(num_examples, shuffle)
+    elif config["name"] in ["frontierscience_olympiad", "frontierscience_research"]:
+        return load_frontierscience_data(
+            task_name=config["name"],
+            num_examples=num_examples,
+            shuffle=shuffle,
+            local_path=local_path,
+        )
     elif config["name"] == "sqav2":
         return load_sqav2_data(num_examples, shuffle)
     elif config["name"] == "genetic_diseases_qa":
@@ -465,6 +476,75 @@ def load_deep_research_bench_data(
                 "additional_instructions": "Please write a well structured, data-driven report on the given research question, and add citations when needed.",
             }
         )
+
+    if shuffle:
+        random.seed(42)
+        random.shuffle(examples)
+
+    if num_examples:
+        examples = examples[:num_examples]
+
+    return examples
+
+
+def load_frontierscience_data(
+    task_name: str,
+    num_examples: Optional[int] = None,
+    shuffle: bool = False,
+    local_path: Optional[str] = None,
+) -> List[Dict]:
+    frontierscience_data_files = {
+        "frontierscience_olympiad": "olympiad/test.jsonl",
+        "frontierscience_research": "research/test.jsonl",
+    }
+
+    if task_name not in frontierscience_data_files:
+        raise ValueError(f"Unsupported FrontierScience task: {task_name}")
+
+    if local_path and Path(local_path).exists():
+        dataset_path = Path(local_path)
+    else:
+        dataset_path = Path(
+            hf_hub_download(
+                repo_id=SUPPORTED_TASKS[task_name],
+                filename=frontierscience_data_files[task_name],
+                repo_type="dataset",
+            )
+        )
+
+    with dataset_path.open("r", encoding="utf-8") as f:
+        raw_examples = [json.loads(line) for line in f if line.strip()]
+
+    examples = []
+    seen_research_task_group_ids = {}
+    for sample in raw_examples:
+        problem = sample["problem"]
+        answer = sample["answer"]
+        if task_name == "frontierscience_olympiad":
+            task_group_id = sample["task_group_id"]
+            example = {
+                "id": task_group_id,
+                "problem": problem,
+                "answer": answer,
+                "additional_instructions": "",
+                "subject": sample.get("subject"),
+            }
+        else:
+            task_group_id = sample["task_group_id"]
+            previous_sample = seen_research_task_group_ids.get(task_group_id)
+            if previous_sample is not None:
+                continue # FrontierScience Research as of 03/18/26 has a dup task...
+
+            seen_research_task_group_ids[task_group_id] = sample
+            example = {
+                "id": task_group_id,
+                "problem": problem,
+                "answer": answer,
+                "additional_instructions": "",
+                "subject": sample.get("subject"),
+            }
+
+        examples.append(example)
 
     if shuffle:
         random.seed(42)

--- a/agent/evaluation/frontier_science_eval/frontierscience_eval.py
+++ b/agent/evaluation/frontier_science_eval/frontierscience_eval.py
@@ -1,0 +1,159 @@
+import re
+from typing import Dict, List
+
+OLYMPIAD_JUDGE_PROMPT = """
+You are grading an attempted answer to a science olympiad problem. You will be given the
+problem, attempted answer, and reference answer. Evaluate the solution against the provided reference solution, ensuring it is complete and matches the reference solution. Pay close attention to detail and grade it strictly, but fairly.
+
+The reference answer is either a single number or expression in latex formatting, a chemical formula, a compound name, or a phrase referring to a specific name, entity, or method.
+
+Mark the attempted answer as correct if it fully matches the reference answer or is otherwise equivalent (e.g., an equivalent algebraic expression, a numerical number within 1 decimal place rounding of the reference answer (e.g., 6.69 ≈ 6.7), an equivalent name for a compound/formula, equivalent when accounting for units, etc.). Mark it as incorrect if it is not equivalent to the reference answer.
+
+***
+The problem: {problem}
+***
+The reference answer: {reference answer}
+***
+The attempted answer: {answer}
+***
+
+First, think step-by-step about whether the attempted answer matches the reference answer. If the attempted answer is correct, write "VERDICT: CORRECT" in the last line of your response, with no other text or formatting. If it is incorrect, write "VERDICT: INCORRECT".
+""".strip()
+
+RESEARCH_JUDGE_PROMPT = """
+You are grading a science exam.
+
+You will be given the problem, attempted answer, and a rubric to grade the answer. The rubric will total up to 10 points.
+
+Evaluate the attemped answer against the provided rubric. Pay close attention to detail and grade it strictly, but fairly. Only evaluate against the rubric, as you yourself should not make any judgements (e.g., even if you think the answer is correct but rubric is wrong, you should treat the rubric as the gold standard). Return the absolute total number of points earned (it can be a decimal based on the rubric).
+
+***
+The problem: {problem}
+***
+The rubric: {rubric}
+***
+The attempted answer: {answer}
+***
+
+First, think step-by-step about each rubric item. Explain your reasoning for each rubric item. Then, tally the points up and write VERDICT: <total_points> in the last line of your response, no other text. For example, VERDICT: 2.5 or VERDICT: 8.
+""".strip()
+
+from evaluation.samplers import common
+from evaluation.samplers._types import Eval, SamplerBase, SingleEvalResult
+
+def _extract_verdict_line(text: str) -> str:
+    for line in reversed(text.splitlines()):
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+class FrontierScienceOlympiadEval(Eval):
+    def __init__(self, grader_model: SamplerBase | None = None):
+        self.grader_model = grader_model
+
+    @staticmethod
+    def parse_verdict(grading_response: str) -> str:
+        verdict_line = _extract_verdict_line(grading_response)
+        match = re.search(r"VERDICT:\s*(CORRECT|INCORRECT)\s*$", verdict_line)
+        if not match:
+            return "INCORRECT"
+        return match.group(1)
+
+    def grade_sample(self, question: str, target: str, predicted_answer: str) -> str:
+        if self.grader_model is None:
+            raise ValueError("grader_model is required for FrontierScience Olympiad")
+
+        grader_prompt = (
+            OLYMPIAD_JUDGE_PROMPT.replace("{problem}", question)
+            .replace("{reference answer}", target)
+            .replace("{answer}", predicted_answer)
+        )
+        prompt_messages = [
+            self.grader_model._pack_message(content=grader_prompt, role="user")
+        ]
+        sampler_response = self.grader_model(prompt_messages)
+        return sampler_response.response_text
+
+    def evaluate(self, generation_data: List[Dict]) -> List[SingleEvalResult]:
+        if self.grader_model is None:
+            raise ValueError("grader_model is required for FrontierScience Olympiad")
+        if not generation_data:
+            return []
+
+        def evaluate_single(gen_data: Dict) -> SingleEvalResult:
+            row = gen_data["row"]
+            response_text = gen_data["response_text"]
+            grader_response = self.grade_sample(row["problem"], row["answer"], response_text)
+            verdict = self.parse_verdict(grader_response)
+            score = 1.0 if verdict == "CORRECT" else 0.0
+            return SingleEvalResult(
+                id=row["id"],
+                score=score,
+                metrics={"accuracy": score},
+                gt_answer=row["answer"],
+                pred_answer=response_text,
+                example_level_metadata={
+                    "grader_response": grader_response,
+                    "verdict": verdict,
+                },
+            )
+
+        return common.map_with_progress(evaluate_single, generation_data, num_threads=5)
+
+
+class FrontierScienceResearchEval(Eval):
+    def __init__(self, grader_model: SamplerBase | None = None):
+        self.grader_model = grader_model
+
+    @staticmethod
+    def parse_verdict(grading_response: str) -> float:
+        verdict_line = _extract_verdict_line(grading_response)
+        match = re.search(r"VERDICT:\s*(-?\d+(?:\.\d+)?)\s*$", verdict_line)
+        if not match:
+            return 0.0
+        return min(10.0, max(0.0, float(match.group(1))))
+
+    def grade_sample(self, question: str, rubric: str, predicted_answer: str) -> str:
+        if self.grader_model is None:
+            raise ValueError("grader_model is required for FrontierScience Research")
+
+        grader_prompt = (
+            RESEARCH_JUDGE_PROMPT.replace("{problem}", question)
+            .replace("{rubric}", rubric)
+            .replace("{answer}", predicted_answer)
+        )
+        prompt_messages = [
+            self.grader_model._pack_message(content=grader_prompt, role="user")
+        ]
+        sampler_response = self.grader_model(prompt_messages)
+        return sampler_response.response_text
+
+    def evaluate(self, generation_data: List[Dict]) -> List[SingleEvalResult]:
+        if self.grader_model is None:
+            raise ValueError("grader_model is required for FrontierScience Research")
+        if not generation_data:
+            return []
+
+        def evaluate_single(gen_data: Dict) -> SingleEvalResult:
+            row = gen_data["row"]
+            response_text = gen_data["response_text"]
+            grader_response = self.grade_sample(row["problem"], row["answer"], response_text)
+            raw_points = self.parse_verdict(grader_response)
+            accuracy = 1.0 if raw_points >= 7.0 else 0.0 # following official eval
+            return SingleEvalResult(
+                id=row["id"],
+                score=accuracy,
+                metrics={
+                    "accuracy": accuracy,
+                    "points": raw_points,
+                },
+                gt_answer=row["answer"],
+                pred_answer=response_text,
+                example_level_metadata={
+                    "grader_response": grader_response,
+                    "verdict": raw_points,
+                },
+            )
+
+        return common.map_with_progress(evaluate_single, generation_data, num_threads=2)

--- a/agent/evaluation/samplers/sampler/chat_completion_sampler.py
+++ b/agent/evaluation/samplers/sampler/chat_completion_sampler.py
@@ -23,8 +23,9 @@ class ChatCompletionSampler(SamplerBase):
         self,
         model: str = "gpt-3.5-turbo",
         system_message: str | None = None,
-        temperature: float = 0.5,
-        max_tokens: int = 4096,
+        temperature: float | None = 0.5,
+        max_tokens: int | None = 4096,
+        reasoning_effort: str | None = None,
     ):
         self.api_key_name = "OPENAI_API_KEY"
         if os.environ.get("AZURE_OPENAI_ENDPOINT"):
@@ -40,6 +41,7 @@ class ChatCompletionSampler(SamplerBase):
         self.system_message = system_message
         self.temperature = temperature
         self.max_tokens = max_tokens
+        self.reasoning_effort = reasoning_effort
         self.image_format = "url"
 
     def _handle_image(
@@ -71,14 +73,22 @@ class ChatCompletionSampler(SamplerBase):
         trial = 0
         while True:
             try:
+                completion_kwargs = {
+                    "model": self.model,
+                    "messages": message_list,
+                }
+                if self.max_tokens is not None:
+                    completion_kwargs["max_tokens"] = self.max_tokens
+                if self.temperature is not None:
+                    completion_kwargs["temperature"] = self.temperature
+                if self.reasoning_effort is not None:
+                    completion_kwargs["reasoning_effort"] = self.reasoning_effort
+
                 response = self.client.chat.completions.create(
-                    model=self.model,
-                    messages=message_list,
-                    temperature=self.temperature,
-                    max_tokens=self.max_tokens,
+                    **completion_kwargs,
                 )
                 content = response.choices[0].message.content
-                if content is None:
+                if content is None or not str(content).strip():
                     raise ValueError("OpenAI API returned empty response; retrying")
                 return SamplerResponse(
                     response_text=content,

--- a/agent/scripts/evaluate.py
+++ b/agent/scripts/evaluate.py
@@ -25,6 +25,10 @@ from dotenv import load_dotenv
 from samplers import common
 
 from evaluation.browse_comp_eval.browsecomp_eval import BrowseCompEval
+from evaluation.frontier_science_eval.frontierscience_eval import (
+    FrontierScienceOlympiadEval,
+    FrontierScienceResearchEval,
+)
 from evaluation.health_bench_eval.healthbench_eval import HealthBenchEval
 from evaluation.research_qa_eval.compute_coverage import compute_coverage
 from evaluation.research_qa_eval.researchqa_eval import ResearchQAEval
@@ -198,6 +202,9 @@ def run_evaluation(
     task_type,
     grader_model="gpt-4o-mini",
     debug=False,
+    reasoning_effort=None,
+    temperature=0,
+    max_tokens=1000,
 ):
     """Run evaluation on the specified JSONL file"""
 
@@ -218,8 +225,9 @@ def run_evaluation(
     grader_sampler = ChatCompletionSampler(
         model=grader_model,
         system_message=OPENAI_SYSTEM_MESSAGE_API,
-        max_tokens=1000,
-        temperature=0,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        reasoning_effort=reasoning_effort,
     )
 
     # Run appropriate evaluation
@@ -235,6 +243,10 @@ def run_evaluation(
         eval_class = ShortFormQAEval(
             task=task, grader_model=grader_sampler, metric="judge"
         )
+    elif task == "frontierscience_olympiad":
+        eval_class = FrontierScienceOlympiadEval(grader_model=grader_sampler)
+    elif task == "frontierscience_research":
+        eval_class = FrontierScienceResearchEval(grader_model=grader_sampler)
     else:
         raise ValueError(f"Unsupported task type: {task}")
 
@@ -350,6 +362,21 @@ def main():
             args.run_mode,
             grader_model=args.grader_model,
             debug=args.debug,
+        )
+    elif args.task in ["frontierscience_olympiad", "frontierscience_research"]:
+        grader_model = args.grader_model
+        if grader_model == parser.get_default("grader_model"):
+            grader_model = "gpt-5"
+        run_evaluation(
+            args.file_path,
+            args.save_path,
+            args.task,
+            args.task_type,
+            grader_model,
+            args.debug,
+            reasoning_effort="high",
+            temperature=None,
+            max_tokens=None,
         )
     else:
         run_evaluation(

--- a/agent/workflows/auto_search_sft.py
+++ b/agent/workflows/auto_search_sft.py
@@ -35,6 +35,50 @@ from rich.table import Table
 dotenv.load_dotenv(Path(__file__).parent.parent.parent / ".env")
 
 
+def _extract_balanced_braced_content(text: str, marker: str) -> Optional[str]:
+    start = text.find(marker)
+    if start == -1:
+        return None
+
+    cursor = start + len(marker)
+    depth = 1
+    collected_chars: list[str] = []
+
+    while cursor < len(text):
+        char = text[cursor]
+
+        if char == "{":
+            depth += 1
+            collected_chars.append(char)
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return "".join(collected_chars).strip()
+            collected_chars.append(char)
+        else:
+            collected_chars.append(char)
+
+        cursor += 1
+
+    return "".join(collected_chars).strip()
+
+
+def _extract_final_answer(output_string: str) -> str:
+    if "</think>" in output_string:
+        output_string = "".join(output_string.split("</think>")[1:]).strip()
+
+    if "<answer>" in output_string:
+        output_string = (
+            output_string.split("<answer>", 1)[1].split("</answer>", 1)[0].strip()
+        )
+
+    boxed_content = _extract_balanced_braced_content(output_string, r"\boxed{")
+    if boxed_content is not None:
+        return boxed_content
+
+    return output_string
+
+
 @dataclass
 class WebPageReaderAgentV2(BaseAgent):
     question: Optional[str] = None
@@ -100,9 +144,14 @@ class SearchAgent(BaseAgent):
             "webwalker",
             "hle",
             "dsqa",
+            "frontierscience_olympiad",
         ]:
             instruction_field_name = "exact_answer"
-        elif dataset_name in ["sqav2", "genetic_diseases_qa"]:
+        elif dataset_name in [
+            "sqav2",
+            "genetic_diseases_qa",
+            "frontierscience_research",
+        ]:
             instruction_field_name = "long_form"
         elif dataset_name in ["healthbench", "deep_research_bench", "researchqa"]:
             instruction_field_name = "short_form"
@@ -150,22 +199,7 @@ class SearchAgent(BaseAgent):
         return messages
 
     def postprocess_output(self, result: Dict[str, Any]) -> str:
-        output_string = result.generated_text
-        if "</think>" in output_string:
-            output_string = "".join(output_string.split("</think>")[1:]).strip()
-
-        if "<answer>" in output_string:
-            output_string = (
-                output_string.split("<answer>")[1].split("</answer>")[0].strip()
-            )
-
-        # Replace the "\boxed{" with "\\boxed{"
-        output_string = output_string.replace("\boxed{", "\\boxed{")
-
-        if "\\boxed{" in output_string:
-            output_string = output_string.split("\\boxed{")[1].split("}")[0].strip()
-
-        return output_string
+        return _extract_final_answer(result.generated_text)
 
 
 @dataclass
@@ -183,9 +217,14 @@ class AnswerAgent(BaseAgent):
             "bc_synthetic_varied_depth_o3_verified",
             "webwalker",
             "webshaper",
+            "frontierscience_olympiad",
         ]:
             instruction_field_name = "exact_answer"
-        elif dataset_name in ["sqav2", "genetic_diseases_qa"]:
+        elif dataset_name in [
+            "sqav2",
+            "genetic_diseases_qa",
+            "frontierscience_research",
+        ]:
             instruction_field_name = "long_form"
         elif dataset_name in ["healthbench", "deep_research_bench", "researchqa"]:
             instruction_field_name = "short_form"
@@ -214,22 +253,7 @@ class AnswerAgent(BaseAgent):
         ]
 
     def postprocess_output(self, result: Dict[str, Any]) -> str:
-        output_string = result.generated_text
-        if "</think>" in output_string:
-            output_string = "".join(output_string.split("</think>")[1:]).strip()
-
-        if "<answer>" in output_string:
-            output_string = (
-                output_string.split("<answer>")[1].split("</answer>")[0].strip()
-            )
-
-        # Replace the "\boxed{" with "\\boxed{"
-        output_string = output_string.replace("\boxed{", "\\boxed{")
-
-        if "\\boxed{" in output_string:
-            output_string = output_string.split("\\boxed{")[1].split("}")[0].strip()
-
-        return output_string
+        return _extract_final_answer(result.generated_text)
 
 
 class NoBrowseTool(BaseTool):


### PR DESCRIPTION
This PR adds [OpenAI's FrontierScience](https://huggingface.co/datasets/openai/frontierscience) benchmark, consisting of an "Olympiad" and a "Research" split. Specifically:
- OpenAI did not provide official inference prompt; kept existing prompt
- Used official judge prompt. For Olympiad, main metric is binary correct/incorrect. For Research, a rubric of 10 items are judged. Following official eval, we use accuracy = 1 *iff* rubric scored >= 7/10
- Followed official eval to use GPT-5 with high reasoning effort as judge. Expensive but probably needed, as the problems are hard to judge.
- OpenAI's official data had a duplicate entry for the Research split...? Currently discards it.

Other Changes:
- Added reasoning-effort toggle to judges, backwards compatible
- Added better `\boxed` parsing, as many math latex were previously incorrectly parsed (e.g., `\boxed{\frac{3}{4}}` was previously parsed as `\frac{3`