### PR TITLE
search_utils/you: prefer YDC_API_KEY env var (keep YOUCOM_API_KEY fallback)

### DIFF
--- a/rl/open-instruct/open_instruct/search_utils/you.py
+++ b/rl/open-instruct/open_instruct/search_utils/you.py
@@ -11,9 +11,12 @@ def get_snippets_for_query(query: str, number_of_results=10) -> List[str]:
     Retrieves the first snippet from a web search API for the given query.
     Raises a ValueError if the API key is missing.
     """
-    api_key = os.environ.get("YOUCOM_API_KEY")
+    # YDC_API_KEY is You.com's canonical env var; YOUCOM_API_KEY kept as fallback.
+    api_key = os.environ.get("YDC_API_KEY") or os.environ.get("YOUCOM_API_KEY")
     if not api_key:
-        raise ValueError("Missing YOUCOM_API_KEY environment variable.")
+        raise ValueError(
+            "Missing YDC_API_KEY (or legacy YOUCOM_API_KEY) environment variable."
+        )
 
     session = create_session_with_retries()
 


### PR DESCRIPTION
## What

Make the You.com search helper prefer the canonical `YDC_API_KEY` environment variable, keeping `YOUCOM_API_KEY` as a backward-compatible fallback.

## Why

`YDC_API_KEY` is You.com's canonical API key env var — used by You.com's own docs/SDK and the LangChain/CrewAI/DSPy integrations. `search_utils/you.py` currently requires `YOUCOM_API_KEY`, which is inconsistent with the rest of the ecosystem.

## Change

```python
api_key = os.environ.get("YDC_API_KEY") or os.environ.get("YOUCOM_API_KEY")
```

`YDC_API_KEY` is used when set; otherwise `YOUCOM_API_KEY` works exactly as before. The error message now references both names.

Part of a cross-ecosystem standardization effort: youdotcom-oss/integration-tracking#30
